### PR TITLE
[CORE-395] Increase Default Buffer Capacity in RocksDB from 4,096 to 8,192.

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDB.java
@@ -88,7 +88,7 @@ public class LabelsStoreRocksDB implements LabelsStore, AutoCloseable {
     final static AtomicLong keyTotalSize = new AtomicLong();
     final static AtomicLong valueTotalSize = new AtomicLong();
 
-    final static int DEFAULT_BUFFER_CAPACITY = 4096;
+    final static int DEFAULT_BUFFER_CAPACITY = 8192;
 
     public enum LabelMode {
         Overwrite {


### PR DESCRIPTION
Immediate fix for the issue. 
Given _we_ are loading the data, we can be confident the new limit will hold for the time-being, while we work on a better solution.