### PR TITLE
[CORE-405] Fix maximum lock count error

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/DatasetGraphABAC.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/DatasetGraphABAC.java
@@ -159,8 +159,21 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
 
     @Override
     public void end() {
+        reEntrantLockWorkaround();
         getOther().end();
         super.end();
+    }
+
+    /**
+     * TODO: Remove this after Jena v5.2 upgrade
+     * If executing a READ txn we need to ensure that the lock gets released
+     * by calling commit() - this ends the transaction properly with no side-effects
+     * due to commit() ignoring non-WRITEs
+     */
+    private void reEntrantLockWorkaround(){
+        if(TxnType.READ.equals(transactionType())) {
+            commit();
+        }
     }
 
     @Override


### PR DESCRIPTION
Adding workaround to ensure READ only transactions end correctly, releasing the lock. Remove after Jena v5.2 is released and pulled in.