### PR TITLE
[CORE-414] Increasing hard-coded Byte Buffer limit from 8192 to 1,048,576.

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDB.java
@@ -88,7 +88,7 @@ public class LabelsStoreRocksDB implements LabelsStore, AutoCloseable {
     final static AtomicLong keyTotalSize = new AtomicLong();
     final static AtomicLong valueTotalSize = new AtomicLong();
 
-    final static int DEFAULT_BUFFER_CAPACITY = 8192;
+    final static int DEFAULT_BUFFER_CAPACITY = 1048576;
 
     public enum LabelMode {
         Overwrite {


### PR DESCRIPTION
Feels a little like overkill given the largest entry was 434779 but lets not take any chances. 

I'll try to prioritise the work to address this properly. 