### PR TITLE
Adding JaCoCo Maven plugin for test coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Run
 
 which creates the `rdf-abac-fmod` module for Fuseki.
 
+For test coverage report run
+```bash
+   mvn clean verify
+```
+Coverage report is then available in the `target/site/jacoco-aggregate` folder of the `rdf-abac-coverage-report` submodule.
+
 ## Usage
 
 To use the library directly in your project:

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <plugin.enforcer>3.5.0</plugin.enforcer>
     <plugin.gpg>3.2.7</plugin.gpg>
     <plugin.install>3.1.3</plugin.install>
+    <plugin.jacoco>0.8.12</plugin.jacoco>
     <plugin.jar>3.4.2</plugin.jar>
     <plugin.javadoc>3.10.1</plugin.javadoc>
     <plugin.nexus>1.7.0</plugin.nexus>
@@ -109,6 +110,7 @@
     <module>rdf-abac-fuseki</module>
     <module>rdf-abac-fuseki-server</module>
     <module>rdf-abac-eval</module>
+    <module>rdf-abac-coverage-report</module>
   </modules>
 
   <dependencyManagement>
@@ -398,6 +400,29 @@
       </plugin>
 
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${plugin.jacoco}</version>
+        <configuration>
+          <propertyName>jacocoArgLine</propertyName>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${plugin.surefire}</version>
@@ -405,7 +430,7 @@
           <includes>
             <include>**/TS_*.java</include>
           </includes>
-            <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+          <argLine>@{jacocoArgLine} -XX:+EnableDynamicAgentLoading</argLine>
         </configuration>
       </plugin>
 
@@ -445,7 +470,7 @@
                 <exclude>**/TS_ABAC_BulkTests.java</exclude>
                 <exclude>**/TS_LabelStoreRocksDB.java</exclude>
               </excludes>
-              <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+              <argLine>@{jacocoArgLine} -XX:+EnableDynamicAgentLoading</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/rdf-abac-coverage-report/pom.xml
+++ b/rdf-abac-coverage-report/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) Telicent Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rdf-abac-coverage-report</artifactId>
+    <packaging>pom</packaging>
+    <name>Telicent ABAC - Aggregate Report</name>
+    <description>Jacoco aggregate coverage report for RDF ABAC</description>
+
+    <parent>
+        <groupId>io.telicent.jena</groupId>
+        <artifactId>rdf-abac</artifactId>
+        <version>0.72.1-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>rdf-abac-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>rdf-abac-eval</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>rdf-abac-fuseki</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${plugin.jacoco}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <dataFileIncludes>
+                                <dataFileInclude>**/jacoco.exec</dataFileInclude>
+                            </dataFileIncludes>
+                            <outputDirectory>
+                                ${project.reporting.outputDirectory}/jacoco-aggregate
+                            </outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/rdf-abac-coverage-report/pom.xml
+++ b/rdf-abac-coverage-report/pom.xml
@@ -59,14 +59,6 @@
                         <goals>
                             <goal>report-aggregate</goal>
                         </goals>
-                        <configuration>
-                            <dataFileIncludes>
-                                <dataFileInclude>**/jacoco.exec</dataFileInclude>
-                            </dataFileIncludes>
-                            <outputDirectory>
-                                ${project.reporting.outputDirectory}/jacoco-aggregate
-                            </outputDirectory>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This PR adds a new Maven module `rdf-abac-coverage-report` which just contains a pom file to create an aggregated coverage report of the Java code in the other Maven modules. This enables you to see all the results from one HTML file.