### PR TITLE
Refactoring of LabelStore and LabelStoreRocksDB to improve testability

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/DatasetGraphABAC.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/DatasetGraphABAC.java
@@ -20,7 +20,6 @@ import io.telicent.jena.abac.ABAC;
 import io.telicent.jena.abac.AE;
 import io.telicent.jena.abac.attributes.AttributeExpr;
 import io.telicent.jena.abac.labels.LabelsStore;
-import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -39,7 +38,9 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
     private final String defaultLabel;
     private final AttributesStore attributesStore;
 
-    /** API: use {@link ABAC#authzDataset} */
+    /**
+     * API: use {@link ABAC#authzDataset}
+     */
     public DatasetGraphABAC(DatasetGraph base, String accessAttributes,
                             LabelsStore labelsStore, String datasetDefaultLabel,
                             AttributesStore attributesStore) {
@@ -51,7 +52,9 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
         this.attributesStore = attributesStore;
     }
 
-    /** Get {@link DatasetGraph} being protected */
+    /**
+     * Get {@link DatasetGraph} being protected
+     */
     public DatasetGraph getData() {
         // Note: DatasetGraphWrapper
         // getBase - recursively unwraps DSG wrapper
@@ -75,28 +78,32 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
     @Override
     public void close() {
         super.close();
-        if ( labelsStore instanceof LabelsStoreRocksDB x ) {
-            try {
-                x.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        try {
+            labelsStore.close();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 
-    /** Return the attribute store for this dataset. */
+    /**
+     * Return the attribute store for this dataset.
+     */
     public AttributesStore attributesStore() {
-        return attributesStore ;
+        return attributesStore;
     }
 
-    /** Return the function for getting the user's attributes for this dataset. */
+    /**
+     * Return the function for getting the user's attributes for this dataset.
+     */
     public AttributesForUser attributesForUser() {
-        return attributesStore::attributes ;
+        return attributesStore::attributes;
     }
 
     // Propagate transactions to the labels store.
 
-    private Transactional getOther() { return labelsStore.getTransactional(); }
+    private Transactional getOther() {
+        return labelsStore.getTransactional();
+    }
 
     @Override
     public void begin() {
@@ -132,7 +139,7 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
     @Override
     public boolean promote() {
         boolean b = super.promote();
-        if ( b )
+        if (b)
             getOther().promote();
         return b;
     }
@@ -140,7 +147,7 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
     @Override
     public boolean promote(Promote type) {
         boolean b = super.promote(type);
-        if ( b )
+        if (b)
             getOther().promote(type);
         return b;
     }

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/Labels.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/Labels.java
@@ -34,7 +34,9 @@ public class Labels {
 
     public static final Logger LOG = LoggerFactory.getLogger(Labels.class);
 
-    /** How to deal with receiving a label to an item that already has a label. */
+    /**
+     * How to deal with receiving a label to an item that already has a label.
+     */
     static final MultipleLabelPolicy multipleLabelPolicy = MultipleLabelPolicy.REPLACE;
 
     public static QuadFilter securityFilterByLabel(DatasetGraph dsgBase, LabelsGetter labels, String defaultLabel, CxtABAC cxt) {
@@ -59,20 +61,22 @@ public class Labels {
      */
     public static LabelsStore createLabelsStoreMem(Graph graph) {
         LabelsStore labelsStore = createLabelsStoreMem();
-        if ( graph != null )
+        if (graph != null)
             labelsStore.addGraph(graph);
         return labelsStore;
     }
 
-    /** Cache/registry of all LabelsStoreRocksDB allocations. */
+    /**
+     * Cache/registry of all LabelsStoreRocksDB allocations.
+     */
     public static Map<File, LabelsStoreRocksDB> rocks = new ConcurrentHashMap<>();
 
     /**
      * Factory for a RocksDB-based label store which stores representations of nodes.
      *
-     * @param dbRoot the root directory of the RocksDB database.
-     * @param labelMode indicates whether to overwrite or merge labels
-     * @param resource RDF Node representing the given apps configuration
+     * @param dbRoot        the root directory of the RocksDB database.
+     * @param labelMode     indicates whether to overwrite or merge labels
+     * @param resource      RDF Node representing the given apps configuration
      * @param storageFormat the storage format to use within RocksDB
      * @return a labels store which stores its labels in a RocksDB database at {@code dbRoot}
      */
@@ -81,8 +85,8 @@ public class Labels {
             final LabelsStoreRocksDB.LabelMode labelMode,
             final Resource resource,
             final StoreFmt storageFormat) throws RocksDBException {
-        return rocks.computeIfAbsent(dbRoot, f->
-                new LabelsStoreRocksDB(dbRoot, storageFormat, labelMode, resource) );
+        return rocks.computeIfAbsent(dbRoot, f ->
+                new LabelsStoreRocksDB(new RocksDBHelper(), dbRoot, storageFormat, labelMode, resource));
     }
 
     /**
@@ -103,8 +107,8 @@ public class Labels {
      */
     public static void closeLabelsStoreRocksDB(final LabelsStore labelsStore) {
         try {
-            if (labelsStore instanceof LabelsStoreRocksDB labelsStoreRocksDB) {
-                labelsStoreRocksDB.close();
+            if (labelsStore != null) {
+                labelsStore.close();
             }
         } catch (Exception e) {
             LOG.error("Problem closing RocksDB label store {}", e.getMessage(), e);
@@ -136,8 +140,12 @@ public class Labels {
      * Fine grain control of filter logging.
      * This can be very verbose so sometimes only parts of test development need this.
      */
-    public static void setLabelFilterLogging(boolean value) { SecurityFilterByLabel.setDebug(value); }
+    public static void setLabelFilterLogging(boolean value) {
+        SecurityFilterByLabel.setDebug(value);
+    }
 
-    public static boolean getLabelFilterLogging() {return  SecurityFilterByLabel.getDebug(); }
+    public static boolean getLabelFilterLogging() {
+        return SecurityFilterByLabel.getDebug();
+    }
 }
 

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStore.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStore.java
@@ -16,22 +16,22 @@
 
 package io.telicent.jena.abac.labels;
 
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiConsumer;
-
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.Transactional;
 import org.apache.jena.system.Txn;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
 /**
  * {@link LabelsStore}s provide a triple to label mapping.
  * <p>
  * They do not support pattern matching; although they can store the pattern and provide it's labels.
  */
-public interface LabelsStore { // extends Transactional {
+public interface LabelsStore extends AutoCloseable { // extends Transactional {
 
     /**
      * Lookup the triple and return the labels associated with it.

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreMem.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreMem.java
@@ -66,6 +66,9 @@ public class LabelsStoreMem implements LabelsStore {
     // Used to give consistent update flushing accumulated triples.
     private final Transactional transactional;
 
+    @Override
+    public void close() throws Exception {}
+
     /**
      * TransactionalNull tracks the transaction state so these
      * calls know if they are part of a write transaction.

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreMemPattern.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreMemPattern.java
@@ -68,6 +68,9 @@ public class LabelsStoreMemPattern implements LabelsStore {
     // Used to give consistent update flushing accumulated triples.
     private final Transactional transactional;
 
+    @Override
+    public void close() throws Exception {}
+
     /**
      * TransactionalNull tracks the transaction state so these
      * calls know if they are part of a write transaction.

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreOne.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreOne.java
@@ -92,4 +92,7 @@ public class LabelsStoreOne implements LabelsStore {
     public void forEach(BiConsumer<Triple, List<String>> action) {
         action.accept(Triple.ANY, labels);
     }
+
+    @Override
+    public void close() throws Exception {}
 }

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreZero.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreZero.java
@@ -85,4 +85,7 @@ public class LabelsStoreZero implements LabelsStore {
 
     @Override
     public void forEach(BiConsumer<Triple, List<String>> action) {}
+
+    @Override
+    public void close() throws Exception {}
 }

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/RocksDBHelper.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/RocksDBHelper.java
@@ -1,0 +1,125 @@
+package io.telicent.jena.abac.labels;
+
+import org.rocksdb.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.telicent.jena.abac.labels.Labels.LOG;
+
+public class RocksDBHelper {
+
+    private final static String CREATE_MESSAGE = "create of RocksDB label store";
+
+    private final AtomicBoolean openFlag = new AtomicBoolean(false);
+
+    private final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+
+    private RocksDB db;
+
+    public RocksDB openDB(final String dbPath) {
+        final ColumnFamilyOptions columnFamilyOptions = configureRocksDBColumnFamilyOptions().setMergeOperator(new StringAppendOperator(""));
+
+        final var defaultDescriptor = new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions);
+        final var cfhSPODescriptor = new ColumnFamilyDescriptor("CF_ABAC_SPO".getBytes(), columnFamilyOptions);
+        // TODO (AP) we need a native comparator if we are to have any kind of
+        // comparator. The performance of Java-based comparators is far too poor for our use case
+        // a comparator is necessary to ensure S,P,O and S,P,Any are close in lookup
+        // which may improve performance but is probably not vital...
+        final var cfhS__Descriptor = new ColumnFamilyDescriptor("CF_ABAC_S**".getBytes(), columnFamilyOptions);
+        final var cfh_P_Descriptor = new ColumnFamilyDescriptor("CF_ABAC_*P*".getBytes(), columnFamilyOptions);
+        final var cfh___Descriptor = new ColumnFamilyDescriptor("CF_ABAC_***".getBytes(), columnFamilyOptions);
+
+        if ( !openFlag.compareAndSet(false, true) ) {
+            throw new RuntimeException("Race condition during " + CREATE_MESSAGE);
+        }
+
+        try (final DBOptions dbOptions = configureRocksDBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true)) {
+            List<ColumnFamilyDescriptor> columnFamilyDescriptorList = List.of(defaultDescriptor, cfhSPODescriptor, cfhS__Descriptor,
+                    cfh_P_Descriptor, cfh___Descriptor);
+
+            db = RocksDB.open(dbOptions, dbPath, columnFamilyDescriptorList, columnFamilyHandleList);
+            LOG.debug("Opened RocksDB instance:{}", db);
+            return db;
+        } catch (RocksDBException e) {
+            if ( !openFlag.compareAndSet(true, false) ) {
+                throw new RuntimeException("Race condition during failing " + CREATE_MESSAGE);
+            }
+            LOG.error("Unable to open/create RocksDB label store: {}", dbPath, e);
+            throw new RuntimeException("Failed " + CREATE_MESSAGE, e);
+        }
+    }
+
+    public void closeDB() {
+        if ( openFlag.compareAndSet(true, false) ) {
+            try {
+                LOG.debug("Closing RocksDB instance:{}",db);
+                db.closeE();
+            } catch ( RocksDBException rocksDBException) {
+                LOG.error("Problem encountered closing RocksDB instance", rocksDBException);
+            }
+        }
+    }
+
+    /**
+     * Set up performance tuning options for column family options as recommended by
+     * <a href=
+     * "https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning">Setup-Options-and-Basic-Tuning</a>
+     *
+     * @return column family options configured as recommended
+     */
+    private ColumnFamilyOptions configureRocksDBColumnFamilyOptions() {
+        var options = new ColumnFamilyOptions();
+        options.setLevelCompactionDynamicLevelBytes(true);
+        options.setCompressionType(CompressionType.LZ4_COMPRESSION);
+        options.setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
+
+        return options;
+    }
+
+    /**
+     * Set up performance tuning options for database options as recommended by
+     * <a href=
+     * "https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning">Setup-Options-and-Basic-Tuning</a>
+     *
+     * @return database options configured as recommended
+     */
+    private DBOptions configureRocksDBOptions() {
+        var options = new Options();
+
+        LOG.debug("Configure RocksDB options from defaults to recommended:");
+        LOG.debug("maxBackgroundJobs {} to {}", options.maxBackgroundJobs(), 6);
+        options.setMaxBackgroundJobs(6);
+        LOG.debug("bytesPerSync {} to {}", options.bytesPerSync(), 1048576);
+        options.setBytesPerSync(1048576);
+        LOG.debug("compactionPriority {} to {}", options.compactionPriority(), CompactionPriority.MinOverlappingRatio);
+        options.setCompactionPriority(CompactionPriority.MinOverlappingRatio);
+
+        var tableOptions = new BlockBasedTableConfig();
+        LOG.debug("blockSize {} to {}", tableOptions.blockSize(), 16 * 1024);
+        tableOptions.setBlockSize(16 * 1024);
+        LOG.debug("cacheIndexAndFilterBlocks {} to {}", tableOptions.cacheIndexAndFilterBlocks(), true);
+        tableOptions.setCacheIndexAndFilterBlocks(true);
+        LOG.debug("pinL0FilterAndIndexBlocksInCache {} to {}", tableOptions.pinL0FilterAndIndexBlocksInCache(), true);
+        tableOptions.setPinL0FilterAndIndexBlocksInCache(true);
+        var newFilterPolicy = new BloomFilter(10.0);
+        LOG.debug("filterPolicy {} to {}", tableOptions.filterPolicy(), newFilterPolicy);
+        tableOptions.setFilterPolicy(newFilterPolicy);
+        LOG.debug("formatVersion {} to {}", tableOptions.formatVersion(), 5);
+        tableOptions.setFormatVersion(5);
+
+        options.setTableFormatConfig(tableOptions);
+
+        return new DBOptions(options);
+    }
+
+    public TransactionalRocksDB getTransactionalRocksDB() {
+        return new TransactionalRocksDB(db);
+    }
+
+    public ColumnFamilyHandle removeFromColumnFamilyHandleList(int index) {
+        return columnFamilyHandleList.remove(index);
+    }
+
+}

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/RocksDBHelper.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/RocksDBHelper.java
@@ -10,7 +10,7 @@ import static io.telicent.jena.abac.labels.Labels.LOG;
 
 public class RocksDBHelper {
 
-    private final static String CREATE_MESSAGE = "create of RocksDB label store";
+    private final static String CREATE_MESSAGE = "creation of RocksDB label store";
 
     private final AtomicBoolean openFlag = new AtomicBoolean(false);
 

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/RocksDBHelper.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/RocksDBHelper.java
@@ -18,6 +18,11 @@ public class RocksDBHelper {
 
     private RocksDB db;
 
+    /**
+     * Returns a new instance of RocksDB
+     * @param dbPath the path to the database
+     * @return the RocksDB instance
+     */
     public RocksDB openDB(final String dbPath) {
         final ColumnFamilyOptions columnFamilyOptions = configureRocksDBColumnFamilyOptions().setMergeOperator(new StringAppendOperator(""));
 
@@ -114,10 +119,19 @@ public class RocksDBHelper {
         return new DBOptions(options);
     }
 
+    /**
+     * Returns a transactional instance based on the underlying RocksDB instance
+     * @return - the transactional RocksDB
+     */
     public TransactionalRocksDB getTransactionalRocksDB() {
         return new TransactionalRocksDB(db);
     }
 
+    /**
+     * Accessor to the ColumnFamilyHandle used within the RocksDB instance
+     * @param index the column index to remove and return
+     * @return the removed ColumnFamilyHandle
+     */
     public ColumnFamilyHandle removeFromColumnFamilyHandleList(int index) {
         return columnFamilyHandleList.remove(index);
     }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractTestLabelMatchPattern.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractTestLabelMatchPattern.java
@@ -46,78 +46,76 @@ public abstract class AbstractTestLabelMatchPattern {
     private static final Node o = SSE.parseNode(":o");
     private static final Node o1 = SSE.parseNode(":o1");
 
-    private LabelsStore labels;
-
     protected abstract LabelsStore createLabelsStore(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt);
-
-    protected abstract void destroyLabelsStore(LabelsStore labels);
 
     static Stream<Arguments> provideLabelAndStorageFmt() {
         return Stream.of(Arguments.of(null, null));
     }
 
-    void createStore(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
-        labels = createLabelsStore(labelMode, storeFmt);
-
+    LabelsStore createStore(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
+        LabelsStore labels = createLabelsStore(labelMode, storeFmt);
         labels.add(s, p, o, "spo");
         labels.add(s, p, ANY_MARKER, "sp_");
         labels.add(s, ANY_MARKER, ANY_MARKER, List.of("s__", "x__"));
         labels.add(ANY_MARKER, p, ANY_MARKER, "_p_");
         labels.add(ANY_MARKER, ANY_MARKER, ANY_MARKER, List.of("___", "any=true"));
-    }
-
-    @AfterEach void destroyStore() {
-        destroyLabelsStore(labels);
+        return labels;
     }
 
     static Triple triple(String string) { return SSE.parseTriple(string); }
 
     @ParameterizedTest(name = "{index}: Store = {1}, LabelMode = {0}")
     @MethodSource("provideLabelAndStorageFmt")
-    public void label_match_basic(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
-        labels = createLabelsStore(labelMode, storeFmt);
-        Triple t = triple("(:s1 :p1 :o1)");
-        List<String> x = labels.labelsForTriples(t);
-        assertEquals(List.of(), x);
+    public void label_match_basic(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) throws Exception {
+        try(LabelsStore labels = createLabelsStore(labelMode, storeFmt)) {
+            Triple t = triple("(:s1 :p1 :o1)");
+            List<String> x = labels.labelsForTriples(t);
+            assertEquals(List.of(), x);
+        }
     }
 
     @ParameterizedTest(name = "{index}: Store = {1}, LabelMode = {0}")
     @MethodSource("provideLabelAndStorageFmt")
-    public void label_match_spo(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
-        createStore(labelMode, storeFmt);
-        match(s, p, o, "spo");
+    public void label_match_spo(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) throws Exception {
+        try(LabelsStore ls = createStore(labelMode, storeFmt)) {
+            match(s, p, o, ls, "spo");
+        }
     }
 
     @ParameterizedTest(name = "{index}: Store = {1}, LabelMode = {0}")
     @MethodSource("provideLabelAndStorageFmt")
-    public void label_match_spx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
-        createStore(labelMode, storeFmt);
-        match(s, p, o1, "sp_");
+    public void label_match_spx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) throws Exception {
+        try(LabelsStore ls = createStore(labelMode, storeFmt)) {
+            match(s, p, o1, ls, "sp_");
+        }
     }
 
     @ParameterizedTest(name = "{index}: Store = {1}, LabelMode = {0}")
     @MethodSource("provideLabelAndStorageFmt")
-    public void label_match_sxx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
-        createStore(labelMode, storeFmt);
-        match(s, p1, o1, "s__", "x__");
+    public void label_match_sxx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) throws Exception {
+        try(LabelsStore ls = createStore(labelMode, storeFmt)) {
+            match(s, p1, o1, ls, "s__", "x__");
+        }
     }
 
     @ParameterizedTest(name = "{index}: Store = {1}, LabelMode = {0}")
     @MethodSource("provideLabelAndStorageFmt")
-    public void label_match_xpx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
-        createStore(labelMode, storeFmt);
-        match(s1, p, o1, "_p_");
+    public void label_match_xpx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) throws Exception {
+        try(LabelsStore ls = createStore(labelMode, storeFmt)) {
+            match(s1, p, o1, ls, "_p_");
+        }
     }
 
     @ParameterizedTest(name = "{index}: Store = {1}, LabelMode = {0}")
     @MethodSource("provideLabelAndStorageFmt")
-    public void label_match_xxx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
-        createStore(labelMode, storeFmt);
-        match(s1, p1, o1, "___", "any=true");
-        match(s1, p1, o1, "any=true", "___");
+    public void label_match_xxx(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) throws Exception {
+        try(LabelsStore ls = createStore(labelMode, storeFmt)) {
+            match(s1, p1, o1, ls, "___", "any=true");
+            match(s1, p1, o1, ls, "any=true", "___");
+        }
     }
 
-    private void match(Node s, Node p, Node o, String...expected) {
+    private void match(Node s, Node p, Node o, LabelsStore labels, String...expected) {
         Triple triple = Triple.create(s, p, o);
         List<String> x = labels.labelsForTriples(triple);
         List<String> e = Arrays.asList(expected);

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractTestLabelsStore.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractTestLabelsStore.java
@@ -44,11 +44,8 @@ public abstract class AbstractTestLabelsStore {
     protected static final Triple triple1 = parseTriple("(:s :p 123)");
     protected static final Triple triple2 = parseTriple("(:s :p 'xyz')");
     final public static String HUGE_STRING = "Ukraine was the center of the first eastern Slavic state, Kyivan Rus, which during the 10th and 11th centuries was the largest and most powerful state in Europe. Weakened by internecine quarrels and Mongol invasions, Kyivan Rus was incorporated into the Grand Duchy of Lithuania and eventually into the Polish-Lithuanian Commonwealth. The cultural and religious legacy of Kyivan Rus laid the foundation for Ukrainian nationalism through subsequent centuries. A new Ukrainian state, the Cossack Hetmanate, was established during the mid-17th century after an uprising against the Poles. Despite continuous Muscovite pressure, the Hetmanate managed to remain autonomous for well over 100 years. During the latter part of the 18th century, most Ukrainian ethnographic territory was absorbed by the Russian Empire. Following the collapse of czarist Russia in 1917, Ukraine achieved a short-lived period of independence (1917-20) but was reconquered and endured a brutal Soviet rule that engineered two forced famines (1921-22 and 1932-33) in which over 8 million died. In World War II, German and Soviet armies were responsible for 7 to 8 million more deaths. Although Ukraine overwhelmingly voted for independence in 1991 around the time of the dissolution of the USSR, democracy and prosperity remained elusive as the legacy of state control, patronage politics, and endemic corruption stalled efforts at economic reform, privatization, and civil liberties. A peaceful mass protest referred to as the \"Orange Revolution\" in the closing months of 2004 and early 2005 forced the authorities to overturn a rigged presidential election and to allow a new internationally monitored vote that swept into power a reformist slate under Viktor YUSHCHENKO. Subsequent internal squabbles in the YUSHCHENKO camp allowed his rival Viktor YANUKOVYCH to stage a comeback in legislative (Rada) elections, become prime minister in August 2006, and be elected president in February 2010. In October 2012, Ukraine held Rada elections, widely criticized by Western observers as flawed due to use of government resources to favor ruling party candidates, interference with media access, and harassment of opposition candidates. President YANUKOVYCHs backtracking on a trade and cooperation agreement with the EU in November 2013 - in favor of closer economic ties with Russia - and subsequent use of force against students, civil society activists, and other civilians in favor of the agreement and fed up with blatant corruption led to a three-month protest occupation of Kyivs central square. The governments use of violence to break up the protest camp in February 2014 led to all out pitched battles, scores of deaths, international condemnation, a failed political deal, and the presidents abrupt departure for Russia. New elections in the spring allowed pro-West president Petro POROSHENKO to assume office in June 2014; he was succeeded by Volodymyr ZELENSKY in May 2019. Shortly after YANUKOVYCHs departure in late February 2014, Russian President PUTIN ordered the invasion of Ukraines Crimean Peninsula falsely claiming the action was to protect ethnic Russians living there. Two weeks later, a \"referendum\" was held regarding the integration of Crimea into the Russian Federation. The \"referendum\" was condemned as illegitimate by the Ukrainian Government, the EU, the US, and the UN General Assembly (UNGA). In response to Russias illegal annexation of Crimea, 100 members of the UN passed UNGA resolution 68/262, rejecting the \"referendum\" as baseless and invalid and confirming the sovereignty, political independence, unity, and territorial integrity of Ukraine. In mid-2014, Russia began supplying proxies in two of Ukraines eastern provinces with manpower, funding, and materiel beginning an armed conflict with the Ukrainian Government. Representatives from Ukraine, Russia, and the unrecognized Russian proxy republics signed the Minsk Protocol and Memorandum in September 2014 with the aim of ending the conflict. However, this agreement failed to stop the fighting or find a political solution. In a renewed attempt to alleviate ongoing clashes, leaders of Ukraine, Russia, France, and Germany negotiated a follow-on Package of Measures in February 2015 to implement the Minsk agreements, but this effort failed as well. By early 2022, more than 14,000 civilians were killed or wounded as a result of the Russian intervention in eastern Ukraine. On 24 February 2022, Russia escalated its conflict with Ukraine by launching a full-scale invasion of the country on several fronts in what has become the largest conventional military attack on a sovereign state in Europe since World War II. The invasion has received near universal international condemnation, and many countries have imposed sanctions on Russia and supplied humanitarian and military aid to Ukraine. Russia made substantial gains in the early weeks of the invasion but underestimated Ukrainian resolve and combat capabilities. By the end of 2022, Ukrainian forces had regained all territories in the north and northeast and made some advances in the east and south. Nonetheless, Russia in late September 2022 unilaterally declared its annexation of four Ukrainian oblasts - Donetsk, Kherson, Luhansk, and Zaporizhzhia - even though none was fully under Russian control. The annexations remain unrecognized by the international community.The invasion has also created Europes largest refugee crisis since World War II. As of 28 December 2023, there were 6.3 million Ukrainian refugees recorded globally, and 3.67 million people were internally displaced as of September 2023.  Nearly 28,500 civilian casualties had been reported, as of 21 November 2023. The invasion of Ukraine remains one of the two largest displacement crises worldwide (the other is the conflict in Syria).The Ukrainian people continue to fiercely resist Russia’s full-scale invasion, which has targeted civilian and critical infrastructure - including energy - to try to break the Ukrainian will. President ZELENSKYY has focused on the civic identity of Ukrainians, regardless of ethnic or linguistic background, to unite the country behind the goals of ending the war by regaining as much territory as possible and advancing Ukraine’s candidacy for membership in the European Union (EU). Support for joining the EU and NATO has grown significantly, overcoming the historical, and sometimes artificial, divide between eastern and western Ukraine.";
-    protected LabelsStore labelsStore;
 
-    /**
-     * Empty {@link LabelsStore}
-     */
+    /** Empty {@link LabelsStore} */
     protected abstract LabelsStore createLabelsStore();
 
     /**
@@ -56,10 +53,11 @@ public abstract class AbstractTestLabelsStore {
      * The default is to create an empty {@link LabelsStore}
      * and call {@link  L#loadStoreFromGraph}.
      */
-    protected LabelsStore createLabelsStore(Graph labelsGraph) {
-        labelsStore = createLabelsStore();
-        L.loadStoreFromGraph(labelsStore, labelsGraph);
-        return labelsStore;
+    protected LabelsStore createLabelsStore(Graph labelsGraph) throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            L.loadStoreFromGraph(labelsStore, labelsGraph);
+            return labelsStore;
+        }
     }
 
     // ----
@@ -83,139 +81,150 @@ public abstract class AbstractTestLabelsStore {
     private static final Graph BAD_PATTERN_BNODE = RDFParser.fromString(labelsGraphBnodeBadPattern, Lang.TTL).toGraph();
 
     @Test
-    public void labelsStore_noLabel() {
-        labelsStore = createLabelsStore();
-        List<String> x = labelsStore.labelsForTriples(triple1);
-        assertEquals(List.of(), x);
+    public void labelsStore_noLabel() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            List<String> x = labelsStore.labelsForTriples(triple1);
+            assertEquals(List.of(), x);
+        }
     }
 
     @Test
-    public void labelsStore_addLabel() {
-        labelsStore = createLabelsStore();
-        labelsStore.add(triple1, "triplelabel");
-        List<String> x = labelsStore.labelsForTriples(triple1);
-        assertEquals(List.of("triplelabel"), x);
+    public void labelsStore_addLabel() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            labelsStore.add(triple1, "triplelabel");
+            List<String> x = labelsStore.labelsForTriples(triple1);
+            assertEquals(List.of("triplelabel"), x);
+        }
     }
 
     @Test
-    public void labelsStore_addLabels_no_interference() {
-        labelsStore = createLabelsStore();
-        labelsStore.add(triple1, "label1");
-        labelsStore.add(triple2, "label2");
-        List<String> x = labelsStore.labelsForTriples(triple1);
-        assertEquals(List.of("label1"), x);
+    public void labelsStore_addLabels_no_interference() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            labelsStore.add(triple1, "label1");
+            labelsStore.add(triple2, "label2");
+            List<String> x = labelsStore.labelsForTriples(triple1);
+            assertEquals(List.of("label1"), x);
+        }
     }
 
     @Test
-    public void labelsStore_addLabels_addDifferentLabel() {
-        labelsStore = createLabelsStore();
-        labelsStore.add(triple1, "label1");
-        labelsStore.add(triple2, "labelx");
-        labelsStore.add(triple1, "label2");
-        List<String> x1 = labelsStore.labelsForTriples(triple1);
-        assertEquals(1, x1.size());
-        assertEquals(x1, List.of("label2"));
-        List<String> x2 = labelsStore.labelsForTriples(triple2);
-        assertEquals(x2, List.of("labelx"));
+    public void labelsStore_addLabels_addDifferentLabel() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            labelsStore.add(triple1, "label1");
+            labelsStore.add(triple2, "labelx");
+            labelsStore.add(triple1, "label2");
+            List<String> x1 = labelsStore.labelsForTriples(triple1);
+            assertEquals(1, x1.size());
+            assertEquals(x1, List.of("label2"));
+            List<String> x2 = labelsStore.labelsForTriples(triple2);
+            assertEquals(x2, List.of("labelx"));
+        }
     }
 
     @Test
-    public void labelsStore_addLabel_is_empty() {
-        labelsStore = createLabelsStore();
-        assertTrue(labelsStore.isEmpty(), "Store is not empty on creation");
-        labelsStore.add(triple1, "label1");
-        assertFalse(labelsStore.isEmpty(), "Store is empty after adding a label");
+    public void labelsStore_addLabel_is_empty() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            assertTrue(labelsStore.isEmpty(), "Store is not empty on creation");
+            labelsStore.add(triple1, "label1");
+            assertFalse(labelsStore.isEmpty(), "Store is empty after adding a label");
+        }
     }
 
     @Test
     public void labels_bad_labels_graph() {
-        assertThrows(LabelsException.class,
-                () -> ABACTests.loggerAtLevel(Labels.LOG, "FATAL",
-                        () -> createLabelsStore(BAD_PATTERN))  // warning and error
+        ABACTests.loggerAtLevel(Labels.LOG, "FATAL", () ->
+                assertThrows(LabelsException.class, () -> createLabelsStore(BAD_PATTERN))
         );
     }
 
     @Test
     public void labels_bad_labels_graph_with_bnode() {
-        assertThrows(LabelsException.class,
-                () -> ABACTests.loggerAtLevel(Labels.LOG, "FATAL",
-                        () -> createLabelsStore(BAD_PATTERN_BNODE))
+        ABACTests.loggerAtLevel(Labels.LOG, "FATAL", () ->
+                assertThrows(LabelsException.class, () -> createLabelsStore(BAD_PATTERN_BNODE))
         );
     }
 
     @Test
-    public void labels_add_bad_label() {
+    public void labels_add_bad_label() throws Exception {
         // Label is a parse error.
         String logLevel = "FATAL";
-        labelsStore = createLabelsStore();
-        ABACTests.loggerAtLevel(ABAC.AttrLOG, logLevel, () -> assertThrows(LabelsException.class, () -> labelsStore.add(triple1, "not .. good")));
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            ABACTests.loggerAtLevel(ABAC.AttrLOG, logLevel, () -> assertThrows(LabelsException.class, () -> labelsStore.add(triple1, "not .. good")));
+        }
     }
 
     @Test
-    public void labels_add_bad_labels_graph() {
-        labelsStore = createLabelsStore();
-        String gs = """
-                PREFIX : <http://example>
-                PREFIX authz: <http://telicent.io/security#>
-                [ authz:pattern 'jibberish' ;  authz:label "allowed" ] .
-                """;
-        Graph addition = RDFParser.fromString(gs, Lang.TTL).toGraph();
+    public void labels_add_bad_labels_graph() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            String gs = """
+                    PREFIX : <http://example>
+                    PREFIX authz: <http://telicent.io/security#>
+                    [ authz:pattern 'jibberish' ;  authz:label "allowed" ] .
+                    """;
+            Graph addition = RDFParser.fromString(gs, Lang.TTL).toGraph();
 
-        ABACTests.loggerAtLevel(Labels.LOG, "FATAL", () -> assertThrows(LabelsException.class,
-                () -> {
-                    labelsStore.addGraph(addition);
-                    labelsStore.labelsForTriples(triple1);
-                }));
+            ABACTests.loggerAtLevel(Labels.LOG, "FATAL", () -> assertThrows(LabelsException.class,
+                    () -> {
+                        labelsStore.addGraph(addition);
+                        labelsStore.labelsForTriples(triple1);
+                    }));
+        }
     }
 
     @Test
-    public void labels_add_same_triple_different_label() {
-        labelsStore = createLabelsStore();
-        List<String> x = labelsStore.labelsForTriples(triple1);
-        labelsStore.add(triple1, "label-1");
-        labelsStore.add(triple1, "label-2");
+    public void labels_add_same_triple_different_label() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            List<String> x = labelsStore.labelsForTriples(triple1);
+            labelsStore.add(triple1, "label-1");
+            labelsStore.add(triple1, "label-2");
 
-        List<String> labels = labelsStore.labelsForTriples(triple1);
-        List<String> expected = List.of("label-2");
-        // Order can not be assumed.
-        assertTrue(ListUtils.equalsUnordered(expected, labels), "Expected: " + expected + "  Got: " + labels);
+            List<String> labels = labelsStore.labelsForTriples(triple1);
+            List<String> expected = List.of("label-2");
+            // Order can not be assumed.
+            assertTrue(ListUtils.equalsUnordered(expected, labels), "Expected: " + expected + "  Got: " + labels);
+        }
     }
 
     @Test
-    public void labels_add_triple_multiple_label() {
-        labelsStore = createLabelsStore();
-        List<String> x = labelsStore.labelsForTriples(triple1);
-        labelsStore.add(triple1, List.of("label-1", "label-2"));
-        List<String> labels = labelsStore.labelsForTriples(triple1);
-        List<String> expected = List.of("label-1", "label-2");
-        // Order is not preserved
-        assertEqualsUnordered(expected, labels);
+    public void labels_add_triple_multiple_label() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            List<String> x = labelsStore.labelsForTriples(triple1);
+            labelsStore.add(triple1, List.of("label-1", "label-2"));
+            List<String> labels = labelsStore.labelsForTriples(triple1);
+            List<String> expected = List.of("label-1", "label-2");
+            // Order is not preserved
+            assertEqualsUnordered(expected, labels);
+        }
     }
 
     @Test
-    public void labels_add_same_triple_same_label() {
-        labelsStore = createLabelsStore();
-        labelsStore.labelsForTriples(triple1);
-        labelsStore.add(triple1, "TheLabel");
-        labelsStore.add(triple1, "TheLabel");
-        List<String> labels = labelsStore.labelsForTriples(triple1);
-        assertEquals(List.of("TheLabel"), labels);
+    public void labels_add_same_triple_same_label() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            labelsStore.labelsForTriples(triple1);
+            labelsStore.add(triple1, "TheLabel");
+            labelsStore.add(triple1, "TheLabel");
+            List<String> labels = labelsStore.labelsForTriples(triple1);
+            assertEquals(List.of("TheLabel"), labels);
+        }
     }
 
     @Test
-    public void labels_add_triple_duplicate_label_in_list() {
-        labelsStore = createLabelsStore();
-        List<String> x = List.of("TheLabel", "TheLabel");
-        assertThrows(LabelsException.class, () -> labelsStore.add(triple1, x));
+    public void labels_add_triple_duplicate_label_in_list() throws Exception {
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            List<String> x = List.of("TheLabel", "TheLabel");
+            assertThrows(LabelsException.class, () -> labelsStore.add(triple1, x));
+        }
     }
 
     @Test
-    public void labelsStore_addHugeLabel() {
+    public void labelsStore_addHugeLabel() throws Exception {
         // 6K string
         Triple hugeTriple = parseTriple("(:s :p '" + HUGE_STRING + "')");
-        labelsStore = createLabelsStore();
-        labelsStore.add(hugeTriple, "hugeLabel");
-        List<String> x = labelsStore.labelsForTriples(hugeTriple);
-        assertEquals(List.of("hugeLabel"), x);
+        try(LabelsStore labelsStore = createLabelsStore()) {
+            labelsStore.add(hugeTriple, "hugeLabel");
+            List<String> x = labelsStore.labelsForTriples(hugeTriple);
+            assertEquals(List.of("hugeLabel"), x);
+        }
     }
+
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
@@ -20,6 +20,7 @@ import io.telicent.jena.abac.attributes.syntax.*;
 import io.telicent.jena.abac.attributes.syntax.tokens.TestToken;
 import io.telicent.jena.abac.attributes.syntax.tokens.TestTokenizerABAC;
 import io.telicent.jena.abac.core.*;
+import io.telicent.jena.abac.labels.TestLabelsStoreRocksDB;
 import io.telicent.jena.abac.labels.TestStoreFmtByNodeId;
 import io.telicent.jena.abac.labels.TestStoreFmtByString;
 import org.junit.platform.suite.api.SelectClasses;
@@ -68,6 +69,7 @@ import org.junit.platform.suite.api.Suite;
     // RocksDB related.
     , TestStoreFmtByString.class
     , TestStoreFmtByNodeId.class
+    , TestLabelsStoreRocksDB.class
 
     , TestLabelStoreRocksDBGeneral.ByString.class
     , TestLabelStoreRocksDBGeneral.ByNodeId.class

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestDatasetPersistentLabelsABAC2.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestDatasetPersistentLabelsABAC2.java
@@ -99,24 +99,25 @@ public class TestDatasetPersistentLabelsABAC2 {
     }
 
     @Test
-    public void dsgz_txn_promote() {
+    public void dsgz_txn_promote() throws Exception {
         final DatasetGraphABAC dsgz = create();
         Triple t = SSE.parseTriple("(:s :p :o)");
         Quad q = Quad.create(Quad.defaultGraphIRI, t);
-        final LabelsStore labelsStore = dsgz.labelsStore();
+        try (final LabelsStore labelsStore = dsgz.labelsStore()) {
 
-        dsgz.exec(TxnType.READ_PROMOTE, ()->{
-            assertTrue(dsgz.getDefaultGraph().isEmpty());
-            assertTrue(dsgz.labelsStore().isEmpty());
+            dsgz.exec(TxnType.READ_PROMOTE, () -> {
+                assertTrue(dsgz.getDefaultGraph().isEmpty());
+                assertTrue(labelsStore.isEmpty());
 
-            dsgz.executeWrite(()->{
-                dsgz.add(q);
-                labelsStore.add(t, "abcdef");
+                dsgz.executeWrite(() -> {
+                    dsgz.add(q);
+                    labelsStore.add(t, "abcdef");
+                });
             });
-        });
-        dsgz.exec(TxnType.READ, ()->{
-            assertFalse(dsgz.getDefaultGraph().isEmpty());
-            assertFalse(dsgz.labelsStore().isEmpty());
-        });
+            dsgz.exec(TxnType.READ, () -> {
+                assertFalse(dsgz.getDefaultGraph().isEmpty());
+                assertFalse(labelsStore.isEmpty());
+            });
+        }
     }
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestLabelsMatchPatternMem.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestLabelsMatchPatternMem.java
@@ -31,8 +31,5 @@ public class TestLabelsMatchPatternMem extends AbstractTestLabelMatchPattern {
         // ignore the label mode - this store doesn't have modes
         return LabelsStoreMemPattern.create();
     }
-
-    @Override
-    protected void destroyLabelsStore(LabelsStore labels) {
-    }
+    
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestLabelsStoreMem.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestLabelsStoreMem.java
@@ -39,9 +39,10 @@ public class TestLabelsStoreMem extends AbstractTestLabelsStore {
     }
 
     @Override
-    protected LabelsStore createLabelsStore(Graph input) {
-        LabelsStore labelStore = createLabelsStore();
-        L.loadStoreFromGraph(labelStore, input);
-        return labelStore;
+    protected LabelsStore createLabelsStore(Graph input) throws Exception {
+        try(LabelsStore labelStore = createLabelsStore()) {
+            L.loadStoreFromGraph(labelStore, input);
+            return labelStore;
+        }
     }
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/AbstractBulkDirectoryRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/AbstractBulkDirectoryRocksDB.java
@@ -25,7 +25,7 @@ public abstract class AbstractBulkDirectoryRocksDB extends BulkDirectory {
 
     @ParameterizedTest
     @MethodSource("provideStorageFmt")
-    public void starWarsReadLoad(StoreFmt storeFmt) throws RocksDBException {
+    public void starWarsReadLoad(StoreFmt storeFmt) throws Exception {
 
         LoadStats stats = bulkLoadAndRepeatedlyRead(CONTENT_DIR, storeFmt,0.01, 1000);
         stats.report("starwars files ");
@@ -34,7 +34,7 @@ public abstract class AbstractBulkDirectoryRocksDB extends BulkDirectory {
     @Disabled("too big/slow - used for manually checking read capacity")
     @ParameterizedTest
     @MethodSource("provideStorageFmt")
-    public void biggerFilesReadLoad(StoreFmt storeFmt) throws RocksDBException {
+    public void biggerFilesReadLoad(StoreFmt storeFmt) throws Exception {
 
         var stats = bulkLoadAndRepeatedlyRead(
             directoryProperty("abac.labelstore.biggerfiles").getAbsolutePath(),
@@ -47,7 +47,7 @@ public abstract class AbstractBulkDirectoryRocksDB extends BulkDirectory {
     @Disabled("too big/slow - used for manually checking read capacity")
     @ParameterizedTest
     @MethodSource("provideStorageFmt")
-    public void biggestFilesReadLoad(StoreFmt storeFmt) throws RocksDBException {
+    public void biggestFilesReadLoad(StoreFmt storeFmt) throws Exception {
 
         var stats = bulkLoadAndRepeatedlyRead(
             directoryProperty("abac.labelstore.biggestfiles").getAbsolutePath(),

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/TestLabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/TestLabelsStoreRocksDB.java
@@ -1,0 +1,4 @@
+package io.telicent.jena.abac.labels;
+
+public class TestLabelsStoreRocksDB {
+}

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/TestLabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/TestLabelsStoreRocksDB.java
@@ -1,4 +1,51 @@
 package io.telicent.jena.abac.labels;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
 public class TestLabelsStoreRocksDB {
+
+    private final RocksDBHelper mockHelper = mock(RocksDBHelper.class);
+    private final ColumnFamilyHandle mockHandle = mock(ColumnFamilyHandle.class);
+    private final RocksDB mockDB = mock(RocksDB.class);
+    private File dbDir;
+
+    @Test
+    public void test_compact() throws Exception {
+        when(mockHelper.removeFromColumnFamilyHandleList(eq(0))).thenReturn(mockHandle);
+        when(mockHelper.openDB(anyString())).thenReturn(mockDB);
+        dbDir = Files.createTempDirectory("tmpDirCompact").toFile();
+        try(LabelsStoreRocksDB labelsStore = new LabelsStoreRocksDB(mockHelper,dbDir, new StoreFmtByString(), LabelsStoreRocksDB.LabelMode.Overwrite, null)){
+            labelsStore.compact();
+            verify(mockDB, times(4)).compactRange(any(),any(),any());
+        }
+    }
+
+    @Test
+    public void test_compact_exception() throws Exception {
+        when(mockHelper.removeFromColumnFamilyHandleList(eq(0))).thenReturn(mockHandle);
+        when(mockHelper.openDB(anyString())).thenReturn(mockDB);
+        doThrow(new RocksDBException("test")).when(mockDB).compactRange(any(),any(),any());
+        dbDir = Files.createTempDirectory("tmpDirCompact").toFile();
+        try(LabelsStoreRocksDB labelsStore = new LabelsStoreRocksDB(mockHelper,dbDir, new StoreFmtByString(), LabelsStoreRocksDB.LabelMode.Overwrite, null)){
+            assertThrows(RuntimeException.class, labelsStore::compact);
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        Files.deleteIfExists(dbDir.toPath());
+    }
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/BaseTestLabelMatchPatternRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/BaseTestLabelMatchPatternRocksDB.java
@@ -24,10 +24,4 @@ public abstract class BaseTestLabelMatchPatternRocksDB extends AbstractTestLabel
             throw new RuntimeException("Unable to create RocksDB label store", e);
         }
     }
-
-    @Override
-    protected void destroyLabelsStore(LabelsStore labels) {
-        dbDirectory.delete();
-        dbDirectory = null;
-    }
 }


### PR DESCRIPTION
The main purpose of this PR is to improve the testability of `LabelStoreRocksDB` by abstracting the RocksDB functionality into the mockable `RocksDBHelper` class. This enables testing of label store functionality without the need to spin up RockDB and instead provide predictable behaviour through mocking.

As a side-effect of this work the extension of `AutoCloseable` has been moved from `LabelStoreRocksDB` to `LabelStore`. This enables the creation of all `LabelStore` instances to be wrapped in a `try-with-resources` statement ensuring the underlying database is always closed (where necessary).

