### PR TITLE
[CORE-687] Add Blank Node Allocator workaround

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/node/BlankNodeAllocatorLabelProvidedWithHash.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/node/BlankNodeAllocatorLabelProvidedWithHash.java
@@ -1,0 +1,23 @@
+package io.telicent.jena.abac.labels.node;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.riot.lang.BlankNodeAllocatorHash;
+import org.apache.jena.riot.out.NodeFmtLib;
+import org.apache.jena.riot.system.MapWithScope;
+
+/**
+ * Workaround class due to limitation in Jena.
+ * Make use of provided id akin to BlankNodeAllocatorLabelEncoded but
+ * leveraging BlankNodeAllocatorHash when creating new
+ */
+public class BlankNodeAllocatorLabelProvidedWithHash extends BlankNodeAllocatorHash implements MapWithScope.Allocator<String, Node, Node> {
+    @Override
+    public Node alloc(String label) {
+        return NodeFactory.createBlankNode(NodeFmtLib.decodeBNodeLabel(label));
+    }
+    @Override
+    public Node alloc(Node scope, String item) {
+        return alloc(item);
+    }
+}

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/node/EmptyScopePolicy.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/node/EmptyScopePolicy.java
@@ -1,0 +1,19 @@
+package io.telicent.jena.abac.labels.node;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.system.MapWithScope;
+
+import java.util.Map;
+
+/**
+ * Workaround class due to inability to access Policy classes within Jena.
+ * (see https://github.com/apache/jena/blob/be5b3bbf6eb3d2704da60aefb0c39f14b0a30a40/jena-arq/src/main/java/org/apache/jena/riot/lang/LabelToNode.java#L142)
+ */
+public class EmptyScopePolicy implements MapWithScope.ScopePolicy<String, Node, Node> {
+    @Override
+    public Map<String, Node> getScope(Node scope) {
+        return null;
+    }
+    @Override
+    public void clear() {}
+}

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/node/LabelToNodeGenerator.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/node/LabelToNodeGenerator.java
@@ -1,0 +1,13 @@
+package io.telicent.jena.abac.labels.node;
+
+import org.apache.jena.riot.lang.LabelToNode;
+
+/**
+ * Workaround class due to limitations in Jena
+ * (see https://github.com/apache/jena/blob/be5b3bbf6eb3d2704da60aefb0c39f14b0a30a40/jena-arq/src/main/java/org/apache/jena/riot/lang/LabelToNode.java#L142)
+ */
+public class LabelToNodeGenerator {
+    public static LabelToNode generate(){
+        return new LabelToNode(new EmptyScopePolicy(), new BlankNodeAllocatorLabelProvidedWithHash());
+    }
+}

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/BulkDirectory.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/BulkDirectory.java
@@ -66,6 +66,7 @@ public abstract class BulkDirectory {
     public static void beforeClass() {
         level = LogCtl.getLevel(BulkDirectory.LOG);
         LogCtl.setLevel(BulkDirectory.LOG, "warn");
+        LogCtl.setLevel(Labels.class, "warn");
     }
 
     @AfterEach

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/node/TestLabelToNodeGenerator.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/node/TestLabelToNodeGenerator.java
@@ -1,0 +1,40 @@
+package io.telicent.jena.abac.labels.node;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.lang.LabelToNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestLabelToNodeGenerator {
+
+    @Test
+    public void test_labelToNode_create() {
+        LabelToNodeGenerator generator = new LabelToNodeGenerator();
+        LabelToNode labelToNode = generator.generate();
+        Node result = labelToNode.create();
+        assertNotNull(result);
+        assertTrue(result.isBlank());
+    }
+
+    @Test
+    public void test_labelToNode_get_label() {
+        LabelToNodeGenerator generator = new LabelToNodeGenerator();
+        LabelToNode labelToNode = generator.generate();
+        Node result = labelToNode.get(null, "label");
+        assertNotNull(result);
+        assertTrue(result.isBlank());
+        assertEquals("_:label", result.toString());
+    }
+
+    @Test
+    public void test_labelToNode_get_encodedLabel() {
+        LabelToNodeGenerator generator = new LabelToNodeGenerator();
+        LabelToNode labelToNode = generator.generate();
+        Node result = labelToNode.get(null, "B12345");
+        assertNotNull(result);
+        assertTrue(result.isBlank());
+        assertEquals("_:12345", result.toString());
+    }
+
+}

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/node/TestLabelToNodeGenerator.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/labels/node/TestLabelToNodeGenerator.java
@@ -18,6 +18,20 @@ public class TestLabelToNodeGenerator {
     }
 
     @Test
+    public void test_labelToNode_create_twice() {
+        LabelToNodeGenerator generator = new LabelToNodeGenerator();
+        LabelToNode labelToNode = generator.generate();
+        Node result = labelToNode.create();
+        assertNotNull(result);
+        assertTrue(result.isBlank());
+        Node result2 = labelToNode.create();
+        assertNotNull(result2);
+        assertTrue(result2.isBlank());
+        assertNotEquals(result.toString(),result2.toString());
+    }
+
+
+    @Test
     public void test_labelToNode_get_label() {
         LabelToNodeGenerator generator = new LabelToNodeGenerator();
         LabelToNode labelToNode = generator.generate();

--- a/rdf-abac-fuseki/pom.xml
+++ b/rdf-abac-fuseki/pom.xml
@@ -84,6 +84,20 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${dependency.mockito}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${dependency.mockito}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestLabelledDataLoader.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestLabelledDataLoader.java
@@ -1,0 +1,380 @@
+package io.telicent.jena.abac.fuseki;
+
+
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sys.JenaSystem;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static io.telicent.jena.abac.fuseki.LabelledDataLoader.ingestData;
+import static io.telicent.jena.abac.fuseki.TestServerABAC.server;
+import static org.apache.jena.fuseki.system.ActionCategory.ACTION;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class TestLabelledDataLoader {
+    static {
+        JenaSystem.init();
+    }
+    private static final HttpServletRequest MOCK_REQUEST = mock(HttpServletRequest.class);
+    private static final HttpServletResponse MOCK_RESPONSE = mock(HttpServletResponse.class);
+    private static final Logger LOGGER = mock(Logger.class);
+    private static final ServletContextHandler SERVLET_CONTEXT_HANDLER = new ServletContextHandler();
+    private static final ServletContext SERVLET_CONTEXT = SERVLET_CONTEXT_HANDLER.getServletContext();
+
+    private static final String TTL_DATA = """
+            PREFIX : <http://example/>
+            :s :p2 123 .
+            :s :p2 456 .
+            """;
+
+    private static final String NQ_DATA = """
+            <http://example/s> <http://example/p2> "123" .
+            <http://example/s> <http://example/p2> "456" .
+            """;
+
+
+    private static final String NQ_NAMED_GRAPH_DATA = """
+            <http://example/s> <http://example/p2> "123" <http://example/> .
+            <http://example/s> <http://example/p2> "456" <http://example/> .
+            """;
+
+
+    @BeforeEach
+    public void setupTest() {
+        when(MOCK_REQUEST.getServletContext()).thenReturn(SERVLET_CONTEXT);
+    }
+
+    @AfterEach
+    public void teardown() {
+        reset(MOCK_REQUEST, MOCK_RESPONSE, LOGGER);
+    }
+
+    @Test
+    public void test_ingestData_nullLang() {
+        // given
+        DatasetGraphABAC datasetGraphABAC = mock(DatasetGraphABAC.class);
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        // then
+        assertNull(results);
+    }
+
+    @Test
+    public void test_ingestData_triples_inputStreamNull() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("text/turtle");
+        when(MOCK_REQUEST.getInputStream()).thenReturn(null);
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        // then
+        assertNull(results);
+    }
+
+    @Test
+    public void test_ingestData_triples_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("text/turtle");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(TTL_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        // then
+        assertNotNull(results);
+        assertEquals(2, results.tripleCount());
+        assertEquals(0, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(6, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+
+    @Test
+    public void test_ingestData_triples_nullLabels_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("text/turtle");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(TTL_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, null, null);
+        // then
+        assertNotNull(results);
+        assertEquals(2, results.tripleCount());
+        assertEquals(0, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+    @Test
+    public void test_ingestData_triples_defaultLabel_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("text/turtle");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(TTL_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("default"), "default");
+        // then
+        assertNotNull(results);
+        assertEquals(2, results.tripleCount());
+        assertEquals(0, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(6, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+
+    @Test
+    public void test_ingestData_triples_differentLabel_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("text/turtle");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(TTL_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"), "default");
+        // then
+        assertNotNull(results);
+        assertEquals(2, results.tripleCount());
+        assertEquals(0, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(8, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+
+    @Test
+    public void test_ingestData_quads_inputStreamNull() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("application/n-quads");
+        when(MOCK_REQUEST.getInputStream()).thenReturn(null);
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        // then
+        assertNull(results);
+    }
+
+    @Test
+    public void test_ingestData_quads_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("application/n-quads");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(NQ_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        // then
+        assertNotNull(results);
+        assertEquals(0, results.tripleCount());
+        assertEquals(2, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+
+    @Test
+    public void test_ingestData_quads_nullLabels_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("application/n-quads");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(NQ_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, null, null);
+        // then
+        assertNotNull(results);
+        assertEquals(0, results.tripleCount());
+        assertEquals(2, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+    @Test
+    public void test_ingestData_quads_defaultLabel_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("application/n-quads");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(NQ_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("default"), "default");
+        // then
+        assertNotNull(results);
+        assertEquals(0, results.tripleCount());
+        assertEquals(2, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(8, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+
+    @Test
+    public void test_ingestData_quads_differentLabel_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("application/n-quads");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(NQ_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"), "default");
+        // then
+        assertNotNull(results);
+        assertEquals(0, results.tripleCount());
+        assertEquals(2, results.quadCount());
+        assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(8, datasetGraphABAC.labelsStore().asGraph().size());
+    }
+
+    @Test
+    public void test_ingestData_quads_namedGraph_happyPath() throws IOException {
+        // given
+        FusekiServer server = server("server-labels/config-labels.ttl");
+        DatasetGraph dsg = server.getDataAccessPointRegistry().get("/ds").getDataService().getDataset();
+        DatasetGraphABAC datasetGraphABAC = (DatasetGraphABAC) dsg;
+
+        when(MOCK_REQUEST.getContentType()).thenReturn("application/n-quads");
+        TestServletInputStream inputStream = new TestServletInputStream(new ByteArrayInputStream(NQ_NAMED_GRAPH_DATA.getBytes()));
+        when(MOCK_REQUEST.getInputStream()).thenReturn(inputStream);
+
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(MOCK_RESPONSE.getOutputStream()).thenReturn(outputStream);
+
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
+        // when
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        // then
+        assertNotNull(results);
+        assertEquals(0, results.tripleCount());
+        assertEquals(2, results.quadCount()); // The Quads are added
+        assertEquals(2, datasetGraphABAC.getDefaultGraph().size()); // makes no difference
+        assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size()); // makes no difference
+    }
+
+    private HttpAction getHttpAction() {
+        return new HttpAction(1L, LOGGER, ACTION, MOCK_REQUEST, MOCK_RESPONSE);
+    }
+
+    private static class TestServletInputStream extends ServletInputStream {
+
+        private final InputStream inputStream;
+
+        public TestServletInputStream(InputStream inputStream) {
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return this.inputStream.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            this.inputStream.close();
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return false;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+
+}

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestLabelledDataLoader.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestLabelledDataLoader.java
@@ -9,7 +9,9 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.servlets.ActionErrorException;
 import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.riot.RiotException;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sys.JenaSystem;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
@@ -89,9 +91,8 @@ public class TestLabelledDataLoader {
         // given
         DatasetGraphABAC datasetGraphABAC = mock(DatasetGraphABAC.class);
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
         // then
-        assertNull(results);
+        assertThrows(ActionErrorException.class, () -> ingestData(getHttpAction(), "base", datasetGraphABAC, List.of()));
     }
 
     @Test
@@ -104,9 +105,8 @@ public class TestLabelledDataLoader {
         when(MOCK_REQUEST.getContentType()).thenReturn("text/turtle");
         when(MOCK_REQUEST.getInputStream()).thenReturn(null);
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
         // then
-        assertNull(results);
+        assertThrows(RiotException.class, () -> ingestData(getHttpAction(), "base", datasetGraphABAC, List.of()));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of());
         // then
         assertNotNull(results);
         assertEquals(2, results.tripleCount());
@@ -152,7 +152,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, null, null);
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, null);
         // then
         assertNotNull(results);
         assertEquals(2, results.tripleCount());
@@ -177,13 +177,13 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("default"), "default");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("default"));
         // then
         assertNotNull(results);
         assertEquals(2, results.tripleCount());
         assertEquals(0, results.quadCount());
         assertEquals(4, datasetGraphABAC.getDefaultGraph().size());
-        assertEquals(6, datasetGraphABAC.labelsStore().asGraph().size());
+        assertEquals(8, datasetGraphABAC.labelsStore().asGraph().size());
     }
 
     @Test
@@ -203,7 +203,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"), "default");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"));
         // then
         assertNotNull(results);
         assertEquals(2, results.tripleCount());
@@ -229,7 +229,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"), "default");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"));
         // then
         assertNotNull(results);
         assertEquals(2, results.tripleCount());
@@ -255,7 +255,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"), "default");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"));
         // then
         assertNotNull(results);
         assertEquals(2, results.tripleCount());
@@ -275,9 +275,8 @@ public class TestLabelledDataLoader {
         when(MOCK_REQUEST.getContentType()).thenReturn("application/n-quads");
         when(MOCK_REQUEST.getInputStream()).thenReturn(null);
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
         // then
-        assertNull(results);
+        assertThrows(RiotException.class, () -> ingestData(getHttpAction(), "base", datasetGraphABAC, List.of()));
     }
 
     @Test
@@ -297,7 +296,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of(), "");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of());
         // then
         assertNotNull(results);
         assertEquals(0, results.tripleCount());
@@ -323,7 +322,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, null, null);
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, null);
         // then
         assertNotNull(results);
         assertEquals(0, results.tripleCount());
@@ -348,7 +347,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("default"), "default");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("default"));
         // then
         assertNotNull(results);
         assertEquals(0, results.tripleCount());
@@ -374,7 +373,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"), "default");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("different"));
         // then
         assertNotNull(results);
         assertEquals(0, results.tripleCount());
@@ -400,7 +399,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("givenlabels"), "defaultlabel");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("givenlabels"));
         // then
         assertNotNull(results);
         assertEquals(0, results.tripleCount());
@@ -426,7 +425,7 @@ public class TestLabelledDataLoader {
         assertEquals(2, datasetGraphABAC.getDefaultGraph().size());
         assertEquals(4, datasetGraphABAC.labelsStore().asGraph().size());
         // when
-        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("givenlabel"), "defaultlabel");
+        LabelledDataLoader.UploadInfo results = ingestData(getHttpAction(), "base", datasetGraphABAC, List.of("givenlabel"));
         // then
         assertNotNull(results);
         assertEquals(0, results.tripleCount());

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestServerABAC.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestServerABAC.java
@@ -129,7 +129,7 @@ public class TestServerABAC {
 //    @AfterAll
 //    public static void cleanup() {}
 
-    private static FusekiServer server(String config) {
+    static FusekiServer server(String config) {
         FusekiModule fmod = new FMod_ABAC();
         FusekiModules mods = FusekiModules.create(fmod);
         return FusekiServer.create()


### PR DESCRIPTION
Improved and corrected the processing of triples & quads, some general tidy up and improved test coverage.