### PR TITLE
[CORE-689] Updating Stream Splitter processing to avoid encoding pre-processed Blank Node.

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/StreamSplitter.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/StreamSplitter.java
@@ -16,12 +16,6 @@
 
 package io.telicent.jena.abac.core;
 
-import static org.apache.jena.riot.out.NodeFmtLib.strNT;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -30,6 +24,12 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.riot.system.StreamRDF;
 import org.apache.jena.riot.system.StreamRDFWrapper;
 import org.apache.jena.sparql.core.Quad;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.jena.riot.out.NodeFmtLib.strNT;
 
 /**
  * Stream to separate out the ABAC graphs (labels) into given graphs
@@ -69,8 +69,23 @@ public class StreamSplitter extends StreamRDFWrapper {
     }
 
     private static Node pattern(Triple triple) {
-        String s = strNT(triple.getSubject())+" "+strNT(triple.getPredicate())+" "+strNT(triple.getObject());
+        String s = obtainStringFromNode(triple.getSubject())+" "+obtainStringFromNode(triple.getPredicate())+" "+obtainStringFromNode(triple.getObject());
         return NodeFactory.createLiteralString(s);
+    }
+
+    /**
+     * Obtain the string representation of given node.
+     * Note: Blank node's have already been processed so do not need
+     * further encoding.
+     * @param node to obtain string from
+     * @return correct representation
+     */
+    private static String obtainStringFromNode(Node node) {
+        if (node.isBlank()) {
+            return node.toString();
+        } else {
+            return strNT(node);
+        }
     }
 
     @Override

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/core/TestStreamSplitter.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/core/TestStreamSplitter.java
@@ -1,0 +1,209 @@
+package io.telicent.jena.abac.core;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestStreamSplitter {
+
+    @Test
+    public void test_prefix() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = List.of();
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        cut.prefix("prefix", "http://example/prefix/");
+        graph.add(Triple.create(NodeFactory.createBlankNode(), NodeFactory.createURI("prefix:test1"), NodeFactory.createURI("prefix:test2")));
+        // then
+        assertFalse(graph.getPrefixMapping().hasNoMappings());
+        assertEquals("http://example/prefix/", graph.getPrefixMapping().getNsPrefixURI("prefix"));
+        assertEquals("prefix", graph.getPrefixMapping().getNsURIPrefix("http://example/prefix/"));
+    }
+
+    @Test
+    public void test_triple_labelsNull() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = null;
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Triple triple = Triple.create(NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.triple(triple);
+        // then
+        assertTrue(graph.isEmpty());
+    }
+
+    @Test
+    public void test_triple_labelsEmpty() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = List.of();
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Triple triple = Triple.create(NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.triple(triple);
+        // then
+        assertTrue(graph.isEmpty());
+    }
+
+    @Test
+    public void test_triple_labelsOneEntry() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = List.of("LABEL");
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Triple triple = Triple.create(NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.triple(triple);
+        // then
+        assertFalse(graph.isEmpty());
+        assertEquals(2, graph.size());
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY));
+        Stream<Triple> tripleStream = graph.stream(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY);
+        Triple match = tripleStream.findFirst().get();
+        assertNotNull(match);
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY));
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL")));
+    }
+
+    @Test
+    public void test_triple_labelsMultipleEntry() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = List.of("LABEL-1","LABEL-2", "LABEL-3");
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Triple triple = Triple.create(NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.triple(triple);
+        // then
+        assertFalse(graph.isEmpty());
+        assertEquals(4, graph.size());
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY));
+        Stream<Triple> tripleStream = graph.stream(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY);
+        Triple match = tripleStream.findFirst().get();
+        assertNotNull(match);
+        assertTrue(graph.contains(match.getSubject(), VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL-1")));
+        assertTrue(graph.contains(match.getSubject(), VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL-2")));
+        assertTrue(graph.contains(match.getSubject(), VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL-3")));
+    }
+
+    @Test
+    public void test_quad_defaultGraphs_labelsNull() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = null;
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Triple triple = Triple.create(NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.triple(triple);
+        // then
+        assertTrue(graph.isEmpty());
+    }
+
+    @Test
+    public void test_quad_defaultGraph_labelsEmpty() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = List.of();
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Quad quad = Quad.create(Quad.defaultGraphIRI, NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.quad(quad);
+        // then
+        assertTrue(graph.isEmpty());
+    }
+
+    @Test
+    public void test_quad_defaultGraph_labelsOneEntry() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = List.of("LABEL");
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Quad quad = Quad.create(Quad.defaultGraphIRI, NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.quad(quad);
+        // then
+        assertFalse(graph.isEmpty());
+        assertEquals(2, graph.size());
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY));
+        Stream<Triple> tripleStream = graph.stream(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY);
+        Triple match = tripleStream.findFirst().get();
+        assertNotNull(match);
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY));
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL")));
+    }
+
+    @Test
+    public void test_quad_defaultGraph_labelsMultipleEntry() {
+        // given
+        StreamRDF data = new TestStreamRDF();
+        Graph graph = GraphFactory.createDefaultGraph();
+        List<String> stringList = List.of("LABEL-1","LABEL-2", "LABEL-3");
+        StreamSplitter cut = new StreamSplitter(data, graph, stringList);
+        // when
+        Quad quad = Quad.create(Quad.defaultGraphIRI, NodeFactory.createBlankNode(), NodeFactory.createLiteralString("test"), NodeFactory.createBlankNode());
+        cut.quad(quad);
+        // then
+        assertFalse(graph.isEmpty());
+        assertEquals(4, graph.size());
+        assertTrue(graph.contains(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY));
+        Stream<Triple> tripleStream = graph.stream(Node.ANY, VocabAuthzLabels.pPattern, Node.ANY);
+        Triple match = tripleStream.findFirst().get();
+        assertNotNull(match);
+        assertTrue(graph.contains(match.getSubject(), VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL-1")));
+        assertTrue(graph.contains(match.getSubject(), VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL-2")));
+        assertTrue(graph.contains(match.getSubject(), VocabAuthzLabels.pLabel, NodeFactory.createLiteralString("LABEL-3")));
+    }
+
+    public class TestStreamRDF implements StreamRDF {
+
+        @Override
+        public void start() {
+
+        }
+
+        @Override
+        public void triple(Triple triple) {
+
+        }
+
+        @Override
+        public void quad(Quad quad) {
+
+        }
+
+        @Override
+        public void base(String base) {
+
+        }
+
+        @Override
+        public void prefix(String prefix, String iri) {
+
+        }
+
+        @Override
+        public void finish() {
+
+        }
+    }
+}


### PR DESCRIPTION
It essentially adds a _:B prefix and so the triple in the label store no longer matches that of the graph.

**Note**: The new unit tests do not cover the entirety of the quad() processing in Stream Splitter due to a lack of understanding as to what the code is trying to achieve. Will hopefully address at a later date.