### PR TITLE
[Minor] Dealing with some warnings from the shade plugin and adding a Label Parsing benchmark class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,13 @@
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>${dependency.commons-beanutils}</version>
+        <exclusions>
+          <!-- To avoid shade overlap warnings -->
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- JUnit 5 -->

--- a/rdf-abac-eval/pom.xml
+++ b/rdf-abac-eval/pom.xml
@@ -50,12 +50,6 @@
       </exclusions>
     </dependency>
 
-    <!-- CVE-2025-48734 -->
-    <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>apache-jena-libs</artifactId>
@@ -115,6 +109,19 @@
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- CVE-2025-48734 -->
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <exclusions>
+        <!-- To avoid shade overlap warnings -->
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/rdf-abac-fuseki-server/pom.xml
+++ b/rdf-abac-fuseki-server/pom.xml
@@ -91,6 +91,12 @@
                                 <exclude>**/module-info.class</exclude>
                             </excludes>
                         </filter>
+                        <filter>
+                            <artifact>org.jspecify:jspecify</artifact>
+                            <excludes>
+                                <exclude>META-INF/versions/9/OSGI-INF/MANIFEST.MF</exclude>
+                            </excludes>
+                        </filter>
                     </filters>
                 </configuration>
                 <executions>

--- a/rdf-abac-fuseki/pom.xml
+++ b/rdf-abac-fuseki/pom.xml
@@ -56,12 +56,6 @@
       </exclusions>
     </dependency>
 
-    <!-- CVE-2025-48734 -->
-    <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-    </dependency>
-
     <!-- Logging dependencies -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -116,6 +110,19 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>${dependency.mockito}</version>
       <scope>test</scope>
+    </dependency>
+
+    <!-- CVE-2025-48734 -->
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <exclusions>
+        <!-- To avoid shade overlap warnings -->
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
The results which are admittedly hard to parse (and very much up for interpretation).

[run_new_stack.txt](https://github.com/user-attachments/files/20674550/run_new_stack.txt)
[run_new_thrpt.txt](https://github.com/user-attachments/files/20674551/run_new_thrpt.txt)
Also carried out some runs on the older repo - pre change. 
[run_old_stack.txt](https://github.com/user-attachments/files/20674564/run_old_stack.txt)
[run_old_thrpt.txt](https://github.com/user-attachments/files/20674565/run_old_thrpt.txt)


I'll not summarise them all but as the table below shows - when checking the throughput; but the new code seems a little more perfomant. 
| Number of Labels | New Parsing (ops/us)   | Old Parsing (ops/us)   |
|------------------|-----------------------|-----------------------|
| 1                | 25.965 ± 0.773        | 23.766 ± 0.425        |
| 10               | 2.455 ± 0.010         | 2.319 ± 0.073         |
| 100              | 0.231 ± 0.001         | 0.223 ± 0.001         |
| 1000             | 0.021 ± 0.001         | 0.020 ± 0.000         |


Anyway.... felt I should share. 