### PR TITLE
[CORE-898] Adding ability to use Auth Server to obtain User Attributes

### DIFF
--- a/docs/abac-fuseki-server.md
+++ b/docs/abac-fuseki-server.md
@@ -14,12 +14,13 @@ Assuming the version of the repo is 0.71.10-SNAPSHOT and the command is being ru
 ```bash
 java -jar ../rdf-abac-fuseki-server/target/rdf-abac-fuseki-server-0.71.10-SNAPSHOT.jar --conf=../rdf-abac-fuseki/src/test/files/server/documentation-example-config.ttl
 ```
-This will run a server accessible from port 3030 with two datasets called `/unsecuredDataset` and `/securedDataset`.
+This will run a server accessible from port 3030 with three datasets called `/unsecuredDataset`, `/legacyDataset` and `/securedDataset`.
 They can be interacted with via the following urls:
-* http://localhost:3030/securedDataset
 * http://localhost:3030/unsecuredDataset
+* http://localhost:3030/legacyDataset
+* http://localhost:3030/securedDataset
 
-As the names suggest, one is configured to make use of ABAC and the other is not.  
+As the names suggest, the first is not configured to make use of ABAC. The other two are. The Secured dataset makes use of the Auth Server component, whereas the legacy dataset makes use of the older ABAC approach.
 
 ### Configuration
 #### Service
@@ -28,9 +29,9 @@ We then further define it to have 3 operations, more colloquially thought of as 
 
 By also providing the endpoints with names, we can ensure that the path is as we would like it to be.
 Note: query is called "query" by default.
-* http://localhost:3030/securedDataset/query
-* http://localhost:3030/securedDataset/read
-* http://localhost:3030/securedDataset/update
+* http://localhost:3030/legacyDataset/query
+* http://localhost:3030/legacyDataset/read
+* http://localhost:3030/legacyDataset/update
 ```rdf
 :secureService rdf:type fuseki:Service ;
     fuseki:name "securedDataset" ;
@@ -55,7 +56,7 @@ Note: query is called "query" by default.
 ### Queries (Secured)
 #### Upload
 ```bash
-curl --location 'http://localhost:3030/securedDataset/upload' \
+curl --location 'http://localhost:3030/legacyDataset/upload' \
 --header 'Security-Label: !' \
 --header 'Content-Type: application/trig' \
 --data-binary '@../rdf-abac-fuseki/src/test/files/server/documentation-example-data.trig'
@@ -66,14 +67,14 @@ curl --location 'http://localhost:3030/securedDataset/upload' \
 ##### User Paul
 This will return all the data that user Paul is able to see.
 ```bash
-curl --location 'http://localhost:3030/securedDataset/read' \
+curl --location 'http://localhost:3030/legacyDataset/read' \
 --header 'Authorization: Bearer dXNlcjpQYXVs'
 ```
 *Note:* We are using the base64 encryption of `user:Paul` to query.
 ##### User Jane
 This will return all the data that user Jane is able to see.
 ```bash
-curl --location 'http://localhost:3030/securedDataset/read' \
+curl --location 'http://localhost:3030/legacyDataset/read' \
 --header 'Authorization: Bearer dXNlcjpKYW5l'
 ```
 *Note:* We are using the base64 encryption of `user:Jane` to query.
@@ -92,7 +93,7 @@ You can swap out the bearer values above for the remaining users (as defined in 
 ##### Count
 This query (for user Jane) will return 6 results as that is all that Jane has access to see.
 ```bash
-curl -X POST --location 'http://localhost:3030/securedDataset/query' \
+curl -X POST --location 'http://localhost:3030/legacyDataset/query' \
 --header 'Accept: application/sparql-results+json' \
 --header 'Content-Type: application/sparql-query' \
 --header 'Authorization: Bearer dXNlcjpKYW5l' \

--- a/docs/abac-hierarchies.md
+++ b/docs/abac-hierarchies.md
@@ -21,3 +21,32 @@ If the data triple has the label
 ```
 
 then a user with attribute value `status=confidental` can see that data triple.
+
+## Fetching hierarchies from Auth Server
+
+If your organization centralizes attribute hierarchies in the Auth Server, expose
+an endpoint such as:
+```
+GET /hierarchy/{attr}
+Accept: application/json
+```
+
+Example response:
+```json
+{
+  "uuid": "6593c90a-dd68-3437-9e0b-b5a69c816dc1",
+  "name": "clearance",
+  "tiers":  ["TS", "S", "O", "U"],
+  "levels": ["TS", "S", "O", "U"]
+}
+```
+
+Configure the ABAC dataset with:
+```
+authz:hierarchiesURL "http://auth.telicent.localhost:9000/hierarchy/{name}" ;
+```
+
+The ABAC engine will call this endpoint for the specific attribute name and build
+a Hierarchy instance. If you instead set a local RDF file, it loads all hierarchies
+eagerly at startup.
+

--- a/docs/abac-user-attribute-store.md
+++ b/docs/abac-user-attribute-store.md
@@ -79,6 +79,46 @@ where environment variable `USER_ATTRIBUTE_STORE` has the value
 ```
 except the URL is not hardcoded into the configuration file.
 
+### Auth Server–backed Attribute Store
+
+If you deploy an Auth Server that exposes a `/userinfo` endpoint, RDF-ABAC can use it
+to obtain user attributes from the presented JWT:
+
+```turtle
+:authzConf a authz:ABAC ;
+    authz:dataset         :dataset ;
+    authz:authServer      true ;
+    # Optional: where to obtain attribute value hierarchies
+    # Use a file path or file: URI to load once:
+    # authz:hierarchiesURL <file:attribute-hierarchies.ttl> ;
+    # Or a remote template to fetch per attribute:
+    # authz:hierarchiesURL "http://auth.telicent.localhost:9000/hierarchy/{name}" ;
+    .
+```
+
+> **Mutual exclusivity**: Do *not* also set `authz:attributes` or `authz:attributesURL` when `authz:authServer true` is used.
+
+
+#### Caching of user info
+
+RDF-ABAC caches the mapping JWT -> username and username -> AttributeValueSet.
+Default TTL and size can be tuned via:
+
+- ABAC_USERINFO_CACHE_TTL_SECONDS (env or system property; default 60)
+
+- ABAC_USERINFO_CACHE_MAX_SIZE (env or system property; default 10000)
+
+
+#### Clarify remote/local/no hierarchies
+
+When `authz:authServer true` is enabled, hierarchies can still be resolved by the ABAC
+engine through `authz:hierarchiesURL`:
+
+- If it’s a local file (path or `file:` URI), the RDF graph is loaded once on startup.
+- If it’s HTTP(S) with a `{name}` variable (e.g., `/hierarchy/{name}`), ABAC fetches
+  hierarchy levels on demand from the Auth Server and caches them per its hierarchy cache settings.
+- If it's not set, we do not carry out hierarchy look-ups.
+
 
 ### Cached User Attributes Store
 As the User & Hierarchy data are unlikely to change very often, we can improve the performance of the Remote Store calls, we can configure the 

--- a/docs/auth-server-integration.md
+++ b/docs/auth-server-integration.md
@@ -1,0 +1,247 @@
+# Auth Server Integration
+
+RDF-ABAC can integrate with an external **Auth Server** to enrich incoming requests with user attributes fetched from the Auth Server’s `/userinfo` endpoint. It can also (optionally) fetch **attribute hierarchies** from the Auth Server via `/hierarchy/{name}`.
+
+This document explains how to enable that flow, what the endpoints should return, and how to operate and troubleshoot the setup.
+
+---
+
+## Overview
+
+- **User attributes**: Read from `Authorization: Bearer <JWT>` using `GET /userinfo`.
+    - The Fuseki runtime adds a filter (`UserInfoEnrichmentFilter`) that calls `/userinfo` and caches the result per token/username.
+- **Hierarchies** (optional): Resolved by the ABAC engine via `authz:hierarchiesURL`.
+    - Can be a **local RDF file** _or_ a **remote HTTP(S) template** like `http://auth…/hierarchy/{name}`.
+
+There are three bearer modes:
+
+- `legacy`   — only the legacy bearer format (e.g., `Bearer user:alice`) is processed.
+- `hybrid`   — **default**; if a JWT is present, call `/userinfo`, else fall back to the legacy filter.
+- `userinfo` — require a valid JWT and call `/userinfo` (401 on missing/invalid token).
+
+---
+
+## Configuration
+
+### 1) Select the attribute store (Auth Server mode)
+
+In your dataset configuration TTL, choose the Auth Server–backed store:
+
+```turtle
+:abacConf a authz:ABAC ;
+    authz:dataset     :dataset ;
+    authz:authServer  true ;
+    # Optional hierarchies (see next section)
+    # authz:hierarchiesURL "http://auth.telicent.localhost:9000/hierarchy/{name}" ;
+    # or
+    # authz:hierarchiesURL <file:attribute-hierarchies.ttl> ;
+    .
+```
+
+> **Important:** Choose **exactly one** of:
+> - `authz:authServer true` (this mode),
+> - `authz:attributes` (local RDF file store), **or**
+> - `authz:attributesURL` (remote legacy store).
+>
+> Setting more than one will be rejected.
+
+### 2) Configure bearer processing mode
+
+Set the bearer mode via **system property** (recommended for tests) or **environment variable**:
+
+```bash
+# system property (recommended for tests):
+-DABAC_AUTH_SERVER_MODE=hybrid
+
+# or environment variable:
+ABAC_AUTH_SERVER_MODE=hybrid
+```
+
+Valid values: `legacy`, `hybrid` (default), `userinfo`.
+
+### 3) Point the filter at your `/userinfo` endpoint
+
+`UserInfoEnrichmentFilter` uses `ABAC_USERINFO_URL`:
+
+```bash
+# system property
+-DABAC_USERINFO_URL=http://auth.telicent.localhost:9000/userinfo
+
+# or environment variable
+ABAC_USERINFO_URL=http://auth.telicent.localhost:9000/userinfo
+```
+
+### 4) (Optional) Configure hierarchies
+
+Tell the ABAC engine where to get attribute hierarchies:
+
+- **From Auth Server (on demand):**
+  ```turtle
+  authz:hierarchiesURL "http://auth.telicent.localhost:9000/hierarchy/{name}" ;
+  ```
+
+- **From local RDF file (loaded at startup):**
+  ```turtle
+  authz:hierarchiesURL <file:attribute-hierarchies.ttl> ;
+  ```
+
+If `authz:hierarchiesURL` is omitted, **no hierarchies** are applied.
+
+---
+
+## Auth Server contracts
+
+### `/userinfo`
+
+- **Method**: `GET`
+- **Auth**: `Authorization: Bearer <JWT>`
+- **Response**: JSON object that includes a username and attributes.
+
+RDF-ABAC extracts the username from the **first present** of:
+`preferred_username`, `username`, `name`, `sub` (must be a **string**).
+
+Attributes can be provided in either of two forms:
+
+1) **Array of normalized strings** under `attributes.abac_attributes`:
+   ```json
+   {
+     "preferred_username": "A067189",
+     "attributes": {
+       "abac_attributes": [
+         "clearance=TS",
+         "compartment.alpha=true",
+         "country=GB"
+       ]
+     }
+   }
+   ```
+
+2) **Object to be flattened** under `attributes`:
+   ```json
+   {
+     "preferred_username": "A067189",
+     "attributes": {
+       "clearance": "TS",
+       "compartment": { "alpha": true, "beta": false },
+       "country": ["GB","US"]
+     }
+   }
+   ```
+   This is flattened to `clearance=TS`, `compartment.alpha=true`, `compartment.beta=false`, `country=GB`, `country=US`.  
+   (Numbers/booleans are converted to strings; nested arrays/objects are traversed.)
+
+- **Success**: any 2xx status + valid JSON as above.
+- **Failure**: non-2xx (e.g. 401) => RDF-ABAC:
+    - **hybrid**: falls back to legacy bearer filter (if present),
+    - **userinfo**: request will be unauthorized.
+
+### `/hierarchy/{name}` (optional)
+
+- **Method**: `GET`
+- **Accept**: `application/json`
+- **Response** (example):
+  ```json
+  {
+    "uuid": "6593c90a-dd68-3437-9e0b-b5a69c816dc1",
+    "name": "clearance",
+    "tiers":  ["TS","S","O","U"],
+    "levels": ["TS","S","O","U"]
+  }
+  ```
+  The ABAC engine consumes the ordered **levels** (alias **tiers** for compatibility) to create a `Hierarchy` for the attribute.
+
+- **404**: treated as “no hierarchy for this attribute”.
+
+---
+
+## Caching & performance
+
+RDF-ABAC caches:
+- **Token → username** and **username → AttributeValueSet** (User Info cache)
+
+Configure via env or system properties:
+
+```bash
+# default 60 seconds
+ABAC_USERINFO_CACHE_TTL_SECONDS=60
+
+# default 10000 entries
+ABAC_USERINFO_CACHE_MAX_SIZE=10000
+```
+
+> Values are honored whether set as environment variables or JVM `-D` properties.
+
+---
+
+## End-to-end examples
+
+### Starting Fuseki with Auth Server integration
+
+```bash
+java   -DABAC_AUTH_SERVER_MODE=hybrid   -DABAC_USERINFO_URL=http://auth.telicent.localhost:9000/userinfo   -jar rdf-abac-fuseki-server/target/rdf-abac-fuseki-server-<VERSION>.jar   path/to/your-config.ttl
+```
+
+### Querying with a JWT
+
+```bash
+curl -sS -X POST 'http://localhost:3030/securedDataset/query'   -H 'Accept: application/sparql-results+json'   -H 'Content-Type: application/sparql-query'   -H "Authorization: Bearer $JWT"   --data 'SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }'
+```
+
+### Hierarchy fetch (manual check)
+
+```bash
+curl -sS 'http://auth.telicent.localhost:9000/hierarchy/clearance'   -H 'Accept: application/json'
+```
+
+---
+
+## Troubleshooting
+
+- **401 `invalid_token`** from `/userinfo`  
+  Check:
+    - The JWT `alg` matches keys in JWKS (e.g., RS256 vs ES256).
+    - The JWT’s `kid` exists in the JWKS set.
+    - `aud` and `iss` are what your Auth Server expects.
+    - Clock skew (check `exp`, `nbf`).
+
+- **No `/userinfo` traffic visible in Auth Server logs**
+    - Client didn’t send `Authorization` header.
+    - You’re in `legacy` mode.
+    - The dataset path is not protected by the bearer filter (verify your FMod order and dataset endpoints).
+
+- **404 for `/hierarchy/{name}`**
+    - ABAC continues without a hierarchy for that attribute.
+    - If you intended to use local hierarchies, make sure `authz:hierarchiesURL` points to a valid file path/`file:` URI.
+
+- **Malformed attribute strings**
+    - If using the normalized array form, entries must look like `key=value`. Invalid pairs are ignored.
+
+- **Performance**
+    - Increase `ABAC_USERINFO_CACHE_TTL_SECONDS` and/or `ABAC_USERINFO_CACHE_MAX_SIZE` for high-throughput workloads.
+    - Ensure your Auth Server and Fuseki are on a low-latency path (or colocated).
+
+---
+
+## Security notes
+
+- **HTTPS** strongly recommended for all Auth Server traffic.
+- Limit scope of tokens (`aud`, `scope`) to only what `/userinfo` needs.
+- If enabling `userinfo` mode (JWT required), deploy appropriate JWKS validation in the Auth Server and ensure Fuseki is not exposed without a reverse proxy if that’s your standard.
+
+---
+
+## Backward compatibility & migration
+
+- `legacy` mode preserves existing `Bearer user:<name>` behavior.
+- `hybrid` mode is a safe on-ramp: JWTs get enriched via `/userinfo`; non-JWT requests still work as before.
+- To enforce JWTs, switch to `userinfo` mode when ready.
+
+---
+
+## Reference (implementation touchpoints)
+
+- Filter: `io.telicent.jena.abac.fuseki.server.UserInfoEnrichmentFilter`
+- Store:  `io.telicent.jena.abac.core.AttributesStoreAuthServer`
+- Module: `io.telicent.jena.abac.fuseki.server.FMod_BearerAuthFilter`
+
+These components are wired so that the filter enriches requests (per mode), the store serves user attributes from the in-JVM cache, and hierarchies are resolved from local RDF or the remote Auth Server, depending on `authz:hierarchiesURL`.

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/Attributes.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/Attributes.java
@@ -139,7 +139,7 @@ public final class Attributes {
         }).collect(Collectors.toSet());
     }
 
-    private static void hierarchies(Graph attributesStoreGraph, AttributesStoreModifiable store) {
+    public static void hierarchies(Graph attributesStoreGraph, AttributesStoreModifiable store) {
         RowSet hierarchies = QueryExec.graph(attributesStoreGraph).query(qHierarchies).select();
         hierarchies.forEachRemaining(row ->{
             String attrName = string(row.get("attribute"));

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/AttributesStoreAuthServer.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/AttributesStoreAuthServer.java
@@ -1,0 +1,210 @@
+package io.telicent.jena.abac.core;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.telicent.jena.abac.AttributeValueSet;
+import io.telicent.jena.abac.Hierarchy;
+import io.telicent.jena.abac.attributes.Attribute;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.http.HttpEnv;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.util.FileUtils;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.telicent.jena.abac.core.Attributes.hierarchies;
+
+/**
+ * {@code AttributesStoreAuthServer} bridges ABAC with a new auth-server model by:
+ * <ul>
+ *   <li>Owning a lightweight, in-memory cache mapping an opaque ID token → username,
+ *       and username → parsed {@link AttributeValueSet} of user attributes.</li>
+ *   <li>Optionally providing hierarchy lookups either from a local RDF file (parsed into a local store)
+ *       or from a remote HTTP(S) hierarchy endpoint (via {@link AttributesStoreRemote}).</li>
+ * </ul>
+ *
+ * <p>The cache is intended to be populated by upstream components (e.g., a servlet filter) after
+ * calling the auth-server {@code /userinfo} endpoint, so that this store can serve attributes without
+ * performing additional network calls.</p>
+ *
+ * <h3>Hierarchy source selection</h3>
+ * <ul>
+ *   <li>If {@code lookupHierarchyURI} is {@code null} or blank → no hierarchy support.</li>
+ *   <li>If {@code lookupHierarchyURI} is a URI (per {@link FileUtils#isURI(String)}) and is not a
+ *       {@code file:} URI → a remote hierarchy store is used.</li>
+ *   <li>Otherwise, the value is treated as a local file path and parsed into an in-memory store.</li>
+ * </ul>
+ *
+ * <h3>Caching configuration</h3>
+ * The caches use Caffeine with a TTL and maximum size configurable via environment variables or
+ * system properties:
+ * <ul>
+ *   <li>{@code ABAC_USERINFO_CACHE_TTL_SECONDS} (default {@code 60})</li>
+ *   <li>{@code ABAC_USERINFO_CACHE_MAX_SIZE}   (default {@code 10000})</li>
+ * </ul>
+ *
+ * @see AttributeValueSet
+ * @see Hierarchy
+ * @see AttributesStoreRemote
+ * @see AttributesStoreLocal
+ */
+public class AttributesStoreAuthServer implements AttributesStore {
+
+    /**
+     * Cache: opaque ID (e.g., access token hash) → username.
+     */
+    private static final Cache<String, String> idToUserName;
+
+    /**
+     * Cache: username → attribute value set parsed from /userinfo.
+     */
+    private static final Cache<String, AttributeValueSet> userNameToAttributes;
+
+    static {
+        long ttl = Long.parseLong(Optional.ofNullable(System.getenv("ABAC_USERINFO_CACHE_TTL_SECONDS"))
+                .orElse(System.getProperty("ABAC_USERINFO_CACHE_TTL_SECONDS", "60")));
+        long max = Long.parseLong(Optional.ofNullable(System.getenv("ABAC_USERINFO_CACHE_MAX_SIZE"))
+                .orElse(System.getProperty("ABAC_USERINFO_CACHE_MAX_SIZE", "10000")));
+        idToUserName = Caffeine.newBuilder()
+                .maximumSize(max)
+                .expireAfterWrite(Duration.ofSeconds(ttl))
+                .build();
+        userNameToAttributes = Caffeine.newBuilder()
+                .maximumSize(max)
+                .expireAfterWrite(Duration.ofSeconds(ttl))
+                .build();
+    }
+
+    /**
+     * Optional delegate used for hierarchy resolution (local or remote).
+     */
+    private final AttributesStore underlyingHierarchyStore;
+
+    /**
+     * Create a store with optional hierarchy support, using the default Jena HTTP client
+     * for any remote calls.
+     *
+     * @param lookupHierarchyURI A file path, a non-{@code file:} URI string, or {@code null}/blank for no hierarchy.
+     *                           See class Javadoc for source selection rules.
+     */
+    public AttributesStoreAuthServer(String lookupHierarchyURI) {
+        this(lookupHierarchyURI, HttpEnv.getDftHttpClient());
+    }
+
+    /**
+     * Create a store with optional hierarchy support, using the provided {@link HttpClient}
+     * for remote hierarchy calls (when applicable).
+     *
+     * @param lookupHierarchyURI A file path, a non-{@code file:} URI string, or {@code null}/blank for no hierarchy.
+     *                           See class Javadoc for source selection rules.
+     * @param httpClient         HTTP client used by {@link AttributesStoreRemote} if a remote hierarchy source is selected.
+     */
+    public AttributesStoreAuthServer(String lookupHierarchyURI, HttpClient httpClient) {
+        if (lookupHierarchyURI == null || lookupHierarchyURI.isEmpty()) {
+            // No hierarchy
+            underlyingHierarchyStore = null;
+        } else if (FileUtils.isURI(lookupHierarchyURI) && !lookupHierarchyURI.startsWith("file:")) {
+            underlyingHierarchyStore = new AttributesStoreRemote("", lookupHierarchyURI, httpClient);
+        } else {
+            AttributesStoreLocal localStore = new AttributesStoreLocal();
+            Graph graph = RDFDataMgr.loadGraph(lookupHierarchyURI);
+            hierarchies(graph, localStore);
+            underlyingHierarchyStore = localStore;
+        }
+    }
+
+    /**
+     * Return the attributes previously cached for a given username.
+     * <p>
+     * This does not query any remote service; values are returned only if they have been
+     * populated via {@link #addUserNameAndAttributes(String, AttributeValueSet)}.
+     *
+     * @param userName the username key
+     * @return the {@link AttributeValueSet} for the user, or {@code null} if not cached
+     */
+    @Override
+    public AttributeValueSet attributes(String userName) {
+        return userNameToAttributes.getIfPresent(userName);
+    }
+
+    /**
+     * Return the configured hierarchy for the given attribute name, if any.
+     * <p>
+     * Delegates to the configured hierarchy store (local or remote) when present. If no hierarchy
+     * store was configured, returns {@code null}.
+     *
+     * @param attribute the attribute for which a hierarchy is requested
+     * @return a {@link Hierarchy} instance or {@code null} if none
+     */
+    @Override
+    public Hierarchy getHierarchy(Attribute attribute) {
+        if (underlyingHierarchyStore != null) {
+            return underlyingHierarchyStore.getHierarchy(attribute);
+        }
+        return null;
+    }
+
+    /**
+     * Return the set of usernames for which attributes are currently cached.
+     * <p>
+     * Note this is <em>not</em> a complete user directory—only users that have been added to
+     * this process using {@link #addUserNameAndAttributes(String, AttributeValueSet)} will appear.
+     *
+     * @return usernames present in the local attribute cache
+     */
+    @Override
+    public Set<String> users() {
+        return userNameToAttributes.asMap().keySet();
+    }
+
+    /**
+     * Determine whether a non-empty hierarchy is available for the given attribute.
+     *
+     * @param attribute the attribute to check
+     * @return {@code true} if a hierarchy exists and contains one or more values; otherwise {@code false}
+     */
+    @Override
+    public boolean hasHierarchy(Attribute attribute) {
+        Hierarchy hierarchy = getHierarchy(attribute);
+        return hierarchy != null && !hierarchy.values().isEmpty();
+    }
+
+    /**
+     * Add or replace the mapping from an opaque ID (e.g., an access token or session ID) to a username.
+     * <p>
+     * Typically called by a request filter after validating /userinfo, so subsequent requests
+     * can recover the username from the same ID without round-tripping to the auth-server.
+     *
+     * @param id       the opaque id (e.g., token)
+     * @param userName the resolved username
+     */
+    public static void addIdAndUserName(String id, String userName) {
+        idToUserName.put(id, userName);
+    }
+
+    /**
+     * Return the username previously cached for the given opaque ID.
+     *
+     * @param id the opaque id (e.g., token)
+     * @return the username or {@code null} if not cached
+     */
+    public static String getCachedUsername(String id) {
+        return idToUserName.getIfPresent(id);
+    }
+
+    /**
+     * Add or replace the attribute set for a username, as parsed from /userinfo.
+     * <p>
+     * This is the main integration point for caching the normalized ABAC attributes that will be used
+     * by downstream authorization checks.
+     *
+     * @param userName          the username key
+     * @param attributeValueSet the parsed attribute values to cache
+     */
+    public static void addUserNameAndAttributes(String userName, AttributeValueSet attributeValueSet) {
+        userNameToAttributes.put(userName, attributeValueSet);
+    }
+}

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/VocabAuthzDataset.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/VocabAuthzDataset.java
@@ -84,6 +84,7 @@ public class VocabAuthzDataset {
      * Cached Attribute Store:
      */
     public static final Property pCachedStore = ResourceFactory.createProperty(NS + "cache");
+    public static final Property pAuthServer = ResourceFactory.createProperty(NS + "authServer");
     public static final Property pAttributeCacheExpiry = ResourceFactory.createProperty(NS + "attributeCacheExpiryTime");
     public static final Property pHierarchyCacheExpiry = ResourceFactory.createProperty(NS + "hierarchyCacheExpiryTime");
     public static final Duration defaultHierarchyCacheExpiry = Duration.ofMinutes(10);

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/core/TestAttributeStoreRemote.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/core/TestAttributeStoreRemote.java
@@ -49,7 +49,7 @@ public class TestAttributeStoreRemote {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void test_attributes_404_reponse() throws Exception {
+    public void test_attributes_404_response() throws Exception {
         AttributesStoreRemote asr = new AttributesStoreRemote("http://localhost:8080/user/{user}", "", mockHttpClient);
         when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(404);

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/core/TestAttributesStoreAuthServer.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/core/TestAttributesStoreAuthServer.java
@@ -1,0 +1,155 @@
+package io.telicent.jena.abac.core;
+
+import io.telicent.jena.abac.AttributeValueSet;
+import io.telicent.jena.abac.attributes.Attribute;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.RDFDataMgr;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class TestAttributesStoreAuthServer {
+
+    private final String uid = "id-" + System.nanoTime();
+    private final String uname = "user-" + System.nanoTime();
+
+    private Path tmpTurtle;
+
+    private HttpClient mockHttpClient;
+    private HttpResponse mockHttpResponse;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tmpTurtle = Files.createTempFile("abac-hierarchies-", ".ttl");
+        Files.writeString(tmpTurtle, "");
+        assertTrue(Files.exists(tmpTurtle));
+        // Sanity: can load empty graph
+        Graph g = RDFDataMgr.loadGraph(tmpTurtle.toAbsolutePath().toString());
+        assertNotNull(g);
+        mockHttpClient = Mockito.mock(HttpClient.class);
+        mockHttpResponse = Mockito.mock(HttpResponse.class);
+
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        if (tmpTurtle != null) {
+            Files.deleteIfExists(tmpTurtle);
+        }
+    }
+
+    @Nested
+    @DisplayName("Static caches")
+    class StaticCaches {
+
+        @Test
+        @DisplayName("addIdAndUserName + getCachedUsername")
+        void idUserCache() {
+            assertNull(AttributesStoreAuthServer.getCachedUsername(uid));
+            AttributesStoreAuthServer.addIdAndUserName(uid, uname);
+            assertEquals(uname, AttributesStoreAuthServer.getCachedUsername(uid));
+        }
+
+        @Test
+        @DisplayName("addUserNameAndAttributes + attributes() + users()")
+        void userAttributesCache() {
+            AttributeValueSet avs = AttributeValueSet.of("role=admin", "clearance=TS");
+            AttributesStoreAuthServer.addUserNameAndAttributes(uname, avs);
+
+            AttributesStoreAuthServer store = new AttributesStoreAuthServer(null, null);
+            assertEquals(avs, store.attributes(uname));
+
+            Set<String> users = store.users();
+            assertTrue(users.contains(uname));
+        }
+    }
+
+    @Nested
+    @DisplayName("Constructor branches & hierarchy calls")
+    class ConstructorsAndHierarchy {
+
+        @Test
+        @DisplayName("Underlying Remote Hierarchy")
+        @SuppressWarnings("unchecked")
+        public void test_remoteHierarchy_() throws Exception {
+            // given
+            AttributesStoreAuthServer asr = new AttributesStoreAuthServer("http://localhost:8080/{name}", mockHttpClient);
+            when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
+            when(mockHttpResponse.statusCode()).thenReturn(200);
+            String responseBody = """
+                    {
+                      "uuid" : "7fdbb786-37e4-3f6c-be99-c9fbb473aa2a" ,
+                      "name" : "findHierarchy" ,
+                      "tiers" : [
+                          "dog" ,
+                          "baby" ,
+                          "junior" ,
+                          "middle" ,
+                          "eldest" ,
+                          "matriarch"
+                        ] ,
+                      "levels" : [
+                          "dog" ,
+                          "baby" ,
+                          "junior" ,
+                          "middle" ,
+                          "eldest" ,
+                          "matriarch"
+                        ]
+                    }
+                    """;
+            InputStream testStream = new ByteArrayInputStream(responseBody.getBytes());
+            when(mockHttpResponse.body()).thenReturn(testStream);
+            // when, then
+            assertNull(asr.attributes("missingUser"));
+            assertTrue(asr.users().isEmpty());
+            assertNotNull(asr.getHierarchy(Attribute.create("findHierarchy")));
+        }
+
+
+        @Test
+        @DisplayName("Local file branch: empty TTL -> no hierarchies")
+        void localFileBranch_noHierarchy() {
+            AttributesStoreAuthServer store = new AttributesStoreAuthServer(tmpTurtle.toAbsolutePath().toString());
+            assertNull(store.getHierarchy(Attribute.create("clearance")));
+            assertFalse(store.hasHierarchy(Attribute.create("clearance")));
+        }
+
+        @Test
+        @DisplayName("Remote URI branch (FileUtils.isURI true): constructor path covered")
+        void remoteUriBranch_constructorCovered() {
+            // http://... is recognized as a URI; we just exercise constructor branch.
+            AttributesStoreAuthServer store = new AttributesStoreAuthServer("http://auth.example/hierarchy/{attr}");
+            assertNotNull(store); // do not call getHierarchy() to avoid network in AttributesStoreRemote
+        }
+
+        @Test
+        @DisplayName("Null hierarchy URL")
+        void noHierarchyBranch() {
+            AttributesStoreAuthServer store1 = new AttributesStoreAuthServer((String) null);
+            assertNull(store1.getHierarchy(Attribute.create("x")));
+            assertFalse(store1.hasHierarchy(Attribute.create("x")));
+        }
+
+        @Test
+        @DisplayName("Blank hierarchy URL")
+        void emptyHierarchyBranch() {
+            AttributesStoreAuthServer store2 = new AttributesStoreAuthServer("");
+            assertNull(store2.getHierarchy(Attribute.create("y")));
+            assertFalse(store2.hasHierarchy(Attribute.create("y")));
+        }
+
+    }
+}

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilter.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilter.java
@@ -295,7 +295,7 @@ public class UserInfoEnrichmentFilter implements Filter {
             return AttributeValueSet.of(out);
         }
 
-        if (v.isObject()) {
+        else if (v.isObject()) {
             processJsonObject(v.getAsObject(), out);
             return AttributeValueSet.of(out);
         }

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilter.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilter.java
@@ -173,7 +173,7 @@ public class UserInfoEnrichmentFilter implements Filter {
                     .GET().build();
 
             HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() / 100 != 2) {
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
                 LOG.error("Unable to fetch user info from {}. Received {} : {}", userInfoUrl, response.statusCode(), response.body());
                 return null;
             }

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilter.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilter.java
@@ -1,0 +1,457 @@
+package io.telicent.jena.abac.fuseki.server;
+
+import io.telicent.jena.abac.AE;
+import io.telicent.jena.abac.AttributeValueSet;
+import io.telicent.jena.abac.attributes.AttributeValue;
+import io.telicent.jena.abac.core.AttributesStoreAuthServer;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.auth.AuthBearerFilter;
+import org.apache.jena.riot.web.HttpNames;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.*;
+
+/**
+ * Servlet {@link Filter} that enriches incoming requests with ABAC user context fetched
+ * from an auth-server {@code /userinfo} endpoint.
+ *
+ * <p>When a request carries an {@code Authorization: Bearer <token>} header:
+ * <ol>
+ *   <li>It first checks the in-process cache managed by
+ *       {@link AttributesStoreAuthServer#getCachedUsername(String)}.</li>
+ *   <li>If absent, it calls the configured {@code /userinfo} endpoint and flattens the JSON payload
+ *       into an {@link AttributeValueSet}, then caches both the username and attributes in
+ *       {@link AttributesStoreAuthServer} for subsequent requests.</li>
+ *   <li>If the userinfo call fails and a {@link #legacyFilter} is present, the request falls back
+ *       to the legacy filter (e.g., header-based user extraction), otherwise the chain continues.</li>
+ * </ol>
+ *
+ * <p>The filter adds the resolved username to the request under
+ * {@link #ATTR_ABAC_USERNAME} so downstream components can identify the principal without
+ * re-contacting the auth-server.</p>
+ *
+ * <h3>Configuration</h3>
+ * <ul>
+ *   <li>{@code ABAC_USERINFO_URL} (env var or system property) — {@code /userinfo} endpoint URL.
+ *       Default: {@code http://auth.telicent.localhost:9000/userinfo}.</li>
+ * </ul>
+ */
+public class UserInfoEnrichmentFilter implements Filter {
+
+    /**
+     * Request attribute key under which this filter stores the resolved username.
+     */
+    public static final String ATTR_ABAC_USERNAME = "abac.user";
+
+    /**
+     * HTTP client used to call the /userinfo endpoint.
+     */
+    private final HttpClient http = HttpClient.newHttpClient();
+
+    /**
+     * Resolved URL of the /userinfo endpoint.
+     */
+    private final String userInfoUrl;
+
+    /**
+     * Optional legacy bearer filter to invoke if userinfo retrieval fails
+     * (e.g., to support "legacy" header-based user extraction).
+     */
+    private final AuthBearerFilter legacyFilter;
+
+    /**
+     * For logging purposes
+     */
+    private static Logger LOG = Fuseki.configLog;
+
+    /**
+     * Construct a filter without a legacy fallback. If the userinfo call fails,
+     * the request proceeds in the chain without enrichment.
+     */
+    public UserInfoEnrichmentFilter() {
+        this(null);
+    }
+
+    /**
+     * Construct a filter with an optional legacy fallback.
+     *
+     * @param legacyFilter an {@link AuthBearerFilter} to delegate to when userinfo retrieval fails,
+     *                     or {@code null} to skip fallback.
+     */
+    public UserInfoEnrichmentFilter(AuthBearerFilter legacyFilter) {
+        this.legacyFilter = legacyFilter;
+        this.userInfoUrl = Optional.ofNullable(System.getenv("ABAC_USERINFO_URL"))
+                .orElse(System.getProperty("ABAC_USERINFO_URL", "http://auth.telicent.localhost:9000/userinfo"));
+    }
+
+    /**
+     * Intercepts requests and attempts to enrich them with ABAC user context from {@code /userinfo}.
+     *
+     * <p>Flow:</p>
+     * <ul>
+     *   <li>Read {@code Authorization} header; if a Bearer token is present, try caches first.</li>
+     *   <li>If not cached, call {@code /userinfo}, flatten attributes, and cache username/attributes.</li>
+     *   <li>On failure and if a legacy filter is provided, delegate to it and return.</li>
+     *   <li>Continue the chain.</li>
+     * </ul>
+     *
+     * @param req   the request
+     * @param resp  the response
+     * @param chain the filter chain
+     * @throws IOException      if the chain throws
+     * @throws ServletException if the chain throws
+     */
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpReq = (HttpServletRequest) req;
+        String authz = httpReq.getHeader(HttpNames.hAuthorization);
+
+        if (authz != null && authz.toLowerCase(Locale.ROOT).startsWith("bearer ")) {
+            String token = authz.substring(7).trim();
+            if (!token.isBlank()) {
+                String username = AttributesStoreAuthServer.getCachedUsername(token);
+                if (username != null) {
+                    req.setAttribute(ATTR_ABAC_USERNAME, username);
+                } else {
+                    CachedUser cu = fetchUserInfo(token);
+                    if (cu != null && cu.attributes != null && cu.username != null) {
+                        req.setAttribute(ATTR_ABAC_USERNAME, cu.username);
+                        // Populate cross-request caches for downstream usage.
+                        AttributesStoreAuthServer.addIdAndUserName(token, cu.username);
+                        AttributesStoreAuthServer.addUserNameAndAttributes(cu.username, cu.attributes);
+                    }
+                    if (cu == null && legacyFilter != null) {
+                        this.legacyFilter.doFilter(req, resp, chain);
+                        return;
+                    }
+                }
+            }
+        }
+        chain.doFilter(req, resp);
+    }
+
+    /**
+     * Immutable container for userinfo results.
+     *
+     * @param username   resolved username
+     * @param attributes flattened/normalized attribute set
+     */
+    private record CachedUser(String username, AttributeValueSet attributes) {
+    }
+
+    /**
+     * Retrieve and parse user information from the configured {@code /userinfo} endpoint.
+     *
+     * <p>Expected payload examples:</p>
+     * <ul>
+     *   <li>{@code preferred_username}/{@code username}/{@code name}/{@code sub} for the username, and</li>
+     *   <li>either {@code attributes.abac_attributes} as an array of {@code "k=v"} strings, or a
+     *       structured {@code attributes} object which is flattened into {@code "k=v"} pairs.</li>
+     * </ul>
+     *
+     * @param token the Bearer token value (without the {@code "Bearer "} prefix)
+     * @return a {@link CachedUser} if successful; otherwise {@code null} (on non-2xx or any exception)
+     */
+    private CachedUser fetchUserInfo(String token) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(userInfoUrl))
+                    .timeout(Duration.ofSeconds(5))
+                    .header(HttpNames.hAuthorization, "Bearer " + token)
+                    .GET().build();
+
+            HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                LOG.error("Unable to fetch user info from {}. Received {} : {}", userInfoUrl, response.statusCode(), response.body());
+                return null;
+            }
+
+            JsonObject j = JSON.parseAny(response.body()).getAsObject();
+            String username = tryFields(j, List.of("preferred_username", "username", "name", "sub"))
+                    .filter(JsonValue::isString)
+                    .map(v -> v.getAsString().value()).orElse(null);
+
+            // Prefer normalised abac_attributes if present; otherwise flatten "attributes" object.
+            AttributeValueSet attrSet = null;
+            JsonValue attributes = j.get("attributes");
+            if (attributes != null && attributes.isObject()) {
+                JsonValue abac = attributes.getAsObject().get("abac_attributes");
+                // If no explicit ABAC list, process the "attributes" object itself.
+                attrSet = flattenToAttributeValueSet(Objects.requireNonNullElse(abac, attributes));
+            }
+            if (attrSet == null) {
+                attrSet = AttributeValueSet.EMPTY;
+            }
+            return new CachedUser(username, attrSet);
+        } catch (Exception e) {
+            LOG.error("Unable to fetch/process user info from {}", userInfoUrl, e);
+            return null;
+        }
+    }
+
+    /**
+     * Return the first non-null field among the supplied {@code names} from a JSON object.
+     *
+     * @param obj   JSON object to scan
+     * @param names candidate field names in priority order
+     * @return the first present {@link JsonValue}, or {@link Optional#empty()} if none
+     */
+    protected static Optional<JsonValue> tryFields(JsonObject obj, List<String> names) {
+        for (String n : names) {
+            JsonValue v = obj.get(n);
+            if (v != null) return Optional.of(v);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Legacy attribute-flattening helper (kept for reference and potential reuse).
+     * <p>Converts a structured {@link JsonObject} into a list of {@code "k=v"} strings, where:
+     * <ul>
+     *   <li>arrays become repeated {@code key=value} entries,</li>
+     *   <li>objects become {@code key.sub=value},</li>
+     *   <li>scalars become {@code key=value}.</li>
+     * </ul>
+     *
+     * @param v a JSON value expected to be an object
+     * @return a list of {@code "k=v"} strings, or {@code null} if {@code v} is not an object
+     */
+    @SuppressWarnings("unused")
+    protected static List<String> flattenFromAttributesObject(JsonValue v) {
+        if (v == null || !v.isObject()) return null;
+        List<String> out = new ArrayList<>();
+        JsonObject obj = v.getAsObject();
+        for (String key : obj.keys()) {
+            JsonValue val = obj.get(key);
+            if (val == null) continue;
+            if (val.isArray()) {
+                JsonArray a = val.getAsArray();
+                a.forEach(x -> {
+                    String s = jsonScalarAsString(x);
+                    if (s != null) {
+                        out.add(key + "=" + s);
+                    }
+                });
+            } else if (val.isObject()) {
+                JsonObject m = val.getAsObject();
+                for (String k : m.keys()) {
+                    String s = jsonScalarAsString(m.get(k));
+                    if (s != null) {
+                        out.add(key + "." + k + "=" + s);
+                    }
+                }
+            } else {
+                String s = jsonScalarAsString(val);
+                if (s != null) {
+                    out.add(key + "=" + s);
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Build an {@link AttributeValueSet} from either:
+     * <ul>
+     *   <li>a {@link JsonArray} of {@code "k=v"} strings, or</li>
+     *   <li>a {@link JsonObject} treated as a structured set of attributes and flattened to {@code "k=v"}.</li>
+     * </ul>
+     * Non-conforming entries are ignored.
+     *
+     * @param v the JSON value to interpret
+     * @return a non-null {@link AttributeValueSet} (possibly empty)
+     */
+    static AttributeValueSet flattenToAttributeValueSet(JsonValue v) {
+        if (v == null) return AttributeValueSet.EMPTY;
+
+        List<AttributeValue> out = new ArrayList<>();
+
+        if (v.isArray()) {
+            // Expect an array of "k=v" strings
+            JsonArray a = v.getAsArray();
+            a.forEach(x -> {
+                if (x != null && x.isString()) {
+                    String s = x.getAsString().value();
+                    if (s != null && !s.isBlank()) {
+                        AttributeValue value = parseValue(s);
+                        if (value != null) {
+                            out.add(value);
+                        }
+                    }
+                }
+            });
+            return AttributeValueSet.of(out);
+        }
+
+        if (v.isObject()) {
+            processJsonObject(v.getAsObject(), out);
+            return AttributeValueSet.of(out);
+        }
+
+        // Anything else can't be interpreted into attributes
+        return AttributeValueSet.EMPTY;
+    }
+
+    /**
+     * Flatten a {@link JsonObject} to a list of {@link AttributeValue}s, applying the rules:
+     * <ul>
+     *   <li>Arrays: {@code key=[v1,v2]} → {@code key=v1}, {@code key=v2}</li>
+     *   <li>Objects: {@code key: {sub: v}} → {@code key.sub=v}</li>
+     *   <li>Scalars: {@code key: v} → {@code key=v}</li>
+     * </ul>
+     * Invalid entries are ignored.
+     *
+     * @param obj the object to flatten
+     * @param out a mutable collection to append results to
+     */
+    static void processJsonObject(JsonObject obj, List<AttributeValue> out) {
+        for (String key : obj.keys()) {
+            JsonValue val = obj.get(key);
+            if (val == null) continue;
+
+            if (val.isArray()) {
+                JsonArray a = val.getAsArray();
+                a.forEach(x -> {
+                    String s = jsonScalarAsString(x);
+                    if (s != null) {
+                        AttributeValue value = parseValue(key + "=" + s);
+                        if (value != null) {
+                            out.add(value);
+                        }
+                    }
+                });
+
+            } else if (val.isObject()) {
+                JsonObject m = val.getAsObject();
+                for (String k : m.keys()) {
+                    String s = jsonScalarAsString(m.get(k));
+                    if (s != null) {
+                        AttributeValue value = parseValue(key + "." + k + "=" + s);
+                        if (value != null) {
+                            out.add(value);
+                        }
+                    }
+                }
+
+            } else {
+                String s = jsonScalarAsString(val);
+                if (s != null) {
+                    AttributeValue value = parseValue(key + "=" + s);
+                    if (value != null) {
+                        out.add(value);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse a single {@code "k=v"} pair into an {@link AttributeValue}, returning {@code null}
+     * if the string is not syntactically valid for {@link AE#parseAttrValue(String)}.
+     *
+     * @param toParse pair in the form {@code "key=value"}
+     * @return parsed {@link AttributeValue}, or {@code null} if invalid
+     */
+    static AttributeValue parseValue(String toParse) {
+        try {
+            return AE.parseAttrValue(toParse);
+        } catch (Exception e) {
+            // NOTE: we will ignore any attributes that don't fit the pattern.
+            return null;
+        }
+    }
+
+    /**
+     * Flatten an array value under a given base key.
+     * <ul>
+     *   <li>Nested arrays are processed recursively with the same base key.</li>
+     *   <li>Objects delegate to {@link #processNestedObject(String, JsonObject, List)} with {@code baseKey} as prefix.</li>
+     *   <li>Scalars become {@code baseKey=value} entries.</li>
+     * </ul>
+     *
+     * @param baseKey prefix to use for generated {@code "k=v"} entries
+     * @param arr     array to process
+     * @param out     output collection
+     */
+    private static void processJsonArray(String baseKey, JsonArray arr, List<AttributeValue> out) {
+        arr.forEach(elem -> {
+            if (elem == null) return;
+
+            if (elem.isArray()) {
+                processJsonArray(baseKey, elem.getAsArray(), out);
+            } else if (elem.isObject()) {
+                processNestedObject(baseKey, elem.getAsObject(), out);
+            } else {
+                String s = jsonScalarAsString(elem);
+                if (s != null) {
+                    AttributeValue value = parseValue(baseKey + "=" + s);
+                    if (value != null) {
+                        out.add(value);
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Flatten a nested object under a given prefix:
+     * <ul>
+     *   <li>Scalars  → {@code prefix.field=value}</li>
+     *   <li>Objects  → recurse with {@code prefix.field} as next prefix</li>
+     *   <li>Arrays   → delegate to {@link #processJsonArray(String, JsonArray, List)} using {@code prefix.field}</li>
+     * </ul>
+     *
+     * @param prefix key prefix to apply
+     * @param obj    nested object to process
+     * @param out    output collection for parsed attribute values
+     */
+    static void processNestedObject(String prefix, JsonObject obj, List<AttributeValue> out) {
+        for (String k : obj.keys()) {
+            JsonValue v = obj.get(k);
+            if (v == null) continue;
+
+            String nextPrefix = prefix + "." + k;
+
+            if (v.isArray()) {
+                processJsonArray(nextPrefix, v.getAsArray(), out);
+            } else if (v.isObject()) {
+                processNestedObject(nextPrefix, v.getAsObject(), out);
+            } else {
+                String s = jsonScalarAsString(v);
+                if (s != null) out.add(parseValue(nextPrefix + "=" + s));
+            }
+        }
+    }
+
+    /**
+     * Convert a scalar {@link JsonValue} to a Java {@link String}.
+     * <ul>
+     *   <li>Strings return their value,</li>
+     *   <li>numbers return {@code toString()},</li>
+     *   <li>booleans return {@code "true"} or {@code "false"},</li>
+     *   <li>arrays/objects return {@code null}.</li>
+     * </ul>
+     *
+     * @param v JSON scalar
+     * @return string representation or {@code null} if not a scalar
+     */
+    static String jsonScalarAsString(JsonValue v) {
+        if (v == null) return null;
+        if (v.isString()) return v.getAsString().value();
+        if (v.isNumber()) return v.getAsNumber().value().toString();
+        if (v.isBoolean()) return Boolean.toString(v.getAsBoolean().value());
+        return null; // arrays/objects handled by callers
+    }
+}

--- a/rdf-abac-fuseki/src/test/files/server/documentation-example-config.ttl
+++ b/rdf-abac-fuseki/src/test/files/server/documentation-example-config.ttl
@@ -1,6 +1,6 @@
-## Operations and fuseki:upload and fuseki:query
-## whose processors are replaced by ABAC versions.
+## Example configuration to highligh some of the ways of working.
 
+## Initial prefixes to reduce what's typed below.
 PREFIX :        <#>
 PREFIX fuseki:  <http://jena.apache.org/fuseki#>
 PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -9,34 +9,64 @@ PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
 PREFIX authz:   <http://telicent.io/security#>
 
-## Note: the secured operation but using DatasetAuthz triggers replacements.
+
+## A "Secure" service that will be configured to use an Auth Server component.
 :secureService rdf:type fuseki:Service ;
     fuseki:name "securedDataset" ;
     fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
     fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
     fuseki:endpoint [ fuseki:operation fuseki:upload ; fuseki:name "upload" ] ;
-    fuseki:dataset :dataset ;
+    fuseki:dataset :authDataset ;
     .
     
-## ABAC Dataset: Initially: no labels, no rules.
-## Default access is applied to entries without labels ("!" no access)
-## DatasetAuthz - is a keyword (https://github.com/telicent-oss/rdf-abac/blob/7f05a5b34e9340e2c7741eb0643422e161e70300/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/VocabAuthzDataset.java#L37)
-
-:dataset rdf:type authz:DatasetAuthz ;
+## An ABAC Dataset that stores the data in-memory and defaults unlabelled data as "!"
+## It will use the Auth Server as an attribute store.
+## If no hierarchiesURL is provided - as in this case; no hierarchies are supported.
+## Otherwise it can be loaded from a file or using an endpoint.
+:authDataset rdf:type authz:DatasetAuthz ;
     authz:dataset :inMemoryDatabase;
-    authz:attributes <file:documentation-example-attribute-store.ttl> ;
+    # Indicate that we are using the Auth Server
+    authz:authServer true;
+    # This needs set to a value - but we do not currently use it (hence "AuthServer")
+    authz:attributes "AuthServer" ;
+    # (Optional) Use Files for Hierarchy information
+    #authz:hierarchiesURL <file:documentation-example-attribute-store.ttl> ;
+    # (Optional) Remote URL endpoint for Hierarchy information
+    #authz:hierarchiesURL "http://auth.telicent.localhost:9000/hierarchy/{name}" ;
     authz:tripleDefaultLabels "!";
     .
 
 ## Store triples in memory, do not persist to disk
 :inMemoryDatabase rdf:type ja:MemoryDataset .
 
-## A server without any authorization. Should not be used unless for testing
-## purposes as does not illustrate ABAC
+## An unsecure service (i.e. without any authorization).
+## Should not be used unless for testing purposes as does not illustrate ABAC
 :unsecureService rdf:type fuseki:Service ;
     fuseki:name "unsecuredDataset" ;
     fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
     fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
     fuseki:endpoint [ fuseki:operation fuseki:upload ; fuseki:name "upload" ] ;
     fuseki:dataset :inMemoryDatabase ;
+    .
+
+## A "Secure" service that will be configured to use the existing "legacy" approach
+## for authentication purposes.
+:legacySecureService rdf:type fuseki:Service ;
+    fuseki:name "legacyDataset" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:upload ; fuseki:name "upload" ] ;
+    fuseki:dataset :legacyDataset ;
+    .
+
+## An ABAC Dataset that stores the data in-memory and defaults unlabelled data as "!"
+## It will NOT use the Auth Server as an attribute store.
+## In this instance it will use the file path provided to load in user attributes
+## and hierarchy information.
+:legacyDataset rdf:type authz:DatasetAuthz ;
+    authz:dataset :inMemoryDatabase;
+    # Indicate that we are NOT using the Auth Server
+    authz:authServer false;
+    authz:attributes <file:documentation-example-attribute-store.ttl> ;
+    authz:tripleDefaultLabels "!";
     .

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilterTest.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/server/UserInfoEnrichmentFilterTest.java
@@ -1,0 +1,635 @@
+package io.telicent.jena.abac.fuseki.server;
+
+import com.sun.net.httpserver.HttpServer;
+import io.telicent.jena.abac.AttributeValueSet;
+import io.telicent.jena.abac.attributes.Attribute;
+import io.telicent.jena.abac.attributes.AttributeValue;
+import io.telicent.jena.abac.attributes.ValueTerm;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
+import org.apache.jena.fuseki.main.auth.AuthBearerFilter;
+import org.apache.jena.riot.web.HttpNames;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.telicent.jena.abac.fuseki.server.UserInfoEnrichmentFilter.ATTR_ABAC_USERNAME;
+import static org.apache.jena.atlas.json.JSON.parseAny;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class UserInfoEnrichmentFilterTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setExecutor(null);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        System.clearProperty("ABAC_USERINFO_URL");
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) server.stop(0);
+        System.clearProperty("ABAC_USERINFO_URL");
+    }
+
+    @Nested
+    public class doFilterTests {
+
+        @Test
+        @DisplayName("Happy Path /userinfo 200 with abac_attributes array")
+        void doFilter_userinfo200_abacArray_setsUser_addsToCache_andContinues() throws Exception {
+            // given
+            server.createContext("/userinfo", ex -> {
+                assertAuthorization(ex, "Bearer token123");
+                setResponse(ex, 200, """
+                        {
+                          "preferred_username":"alice",
+                          "attributes":{
+                            "abac_attributes":["dept=eng","not-a-pair","clearance=TS"]
+                          }
+                        }""");
+            });
+            System.setProperty("ABAC_USERINFO_URL", baseUrl + "/userinfo");
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter(legacy);
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn("Bearer token123");
+
+            // Mock static cache interactions
+            try (MockedStatic<io.telicent.jena.abac.core.AttributesStoreAuthServer> st =
+                         mockStatic(io.telicent.jena.abac.core.AttributesStoreAuthServer.class)) {
+                st.when(() -> io.telicent.jena.abac.core.AttributesStoreAuthServer.getCachedUsername("token123"))
+                        .thenReturn(null);
+
+                // when
+                f.doFilter(req, resp, chain);
+
+                // then
+                verify(req).setAttribute(ATTR_ABAC_USERNAME, "alice");
+                verify(chain).doFilter(req, resp);
+                verifyNoInteractions(legacy);
+                st.verify(() -> io.telicent.jena.abac.core.AttributesStoreAuthServer.addIdAndUserName("token123", "alice"));
+                st.verify(() -> io.telicent.jena.abac.core.AttributesStoreAuthServer.addUserNameAndAttributes(eq("alice"), any()), times(1));
+            }
+        }
+
+        @Test
+        @DisplayName("Happy Path /userinfo 200 with nested array")
+        void doFilter_userinfo200_attributesObject_deepFlatten() throws Exception {
+            // given
+            server.createContext("/userinfo", ex -> {
+                assertAuthorization(ex, "Bearer ZZZ");
+                setResponse(ex, 200, """
+                        {
+                          "sub": "user123",
+                          "attributes": {
+                            "dept": "eng",
+                            "clearance": ["TS","S"],
+                            "meta": {
+                              "oncall": true,
+                              "level": 3,
+                              "tags": ["x","y"],
+                              "deep": { "inner":"v" }
+                            }
+                          }
+                        }""");
+            });
+            System.setProperty("ABAC_USERINFO_URL", baseUrl + "/userinfo");
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter(legacy);
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn("BEARER ZZZ"); // case-insensitivity branch
+
+            try (MockedStatic<io.telicent.jena.abac.core.AttributesStoreAuthServer> st =
+                         mockStatic(io.telicent.jena.abac.core.AttributesStoreAuthServer.class)) {
+                st.when(() -> io.telicent.jena.abac.core.AttributesStoreAuthServer.getCachedUsername("ZZZ"))
+                        .thenReturn(null);
+
+                // when
+                f.doFilter(req, resp, chain);
+
+                // then
+                verify(req).setAttribute(ATTR_ABAC_USERNAME, "user123");
+                verify(chain).doFilter(req, resp);
+                verifyNoInteractions(legacy);
+
+                // ensure attributes were added (we don't introspect the set deeply here)
+                st.verify(() -> io.telicent.jena.abac.core.AttributesStoreAuthServer.addUserNameAndAttributes(eq("user123"), any()), times(1));
+            }
+        }
+
+        @Test
+        @DisplayName("Handle /userinfo 401 response - legacy path")
+        void doFilter_userinfo401_fallsBackToLegacy() throws Exception {
+            // given
+            server.createContext("/userinfo", ex -> setResponse(ex, 401, ""));
+            System.setProperty("ABAC_USERINFO_URL", baseUrl + "/userinfo");
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter(legacy);
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn("Bearer bad");
+
+            // when
+            f.doFilter(req, resp, chain);
+
+            // then
+            verify(legacy, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class), any(FilterChain.class));
+            verify(chain, never()).doFilter(req, resp);
+            verify(req, never()).setAttribute(eq(ATTR_ABAC_USERNAME), any());
+        }
+
+        @Test
+        @DisplayName("Handle /userinfo exception - legacy path")
+        void bearer_userinfoThrows_fallsBackToLegacy() throws Exception {
+            // given
+            System.setProperty("ABAC_USERINFO_URL", "http://rubbish/userinfo");
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter(legacy);
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn("Bearer xyz");
+
+            // when
+            f.doFilter(req, resp, chain);
+
+            // then
+            verify(legacy, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class), any(FilterChain.class));
+            verify(chain, never()).doFilter(req, resp);
+        }
+
+        @Test
+        @DisplayName("Handle /userinfo 401 response - no legacy path")
+        void doFilter_userinfo401_fallsBackToLegacy_notSet() throws Exception {
+            // given
+            server.createContext("/userinfo", ex -> setResponse(ex, 401, ""));
+            System.setProperty("ABAC_USERINFO_URL", baseUrl + "/userinfo");
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter();
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn("Bearer bad");
+
+            // when
+            f.doFilter(req, resp, chain);
+
+            // then
+            verify(legacy, never()).doFilter(any(ServletRequest.class), any(ServletResponse.class), any(FilterChain.class));
+            verify(chain, times(1)).doFilter(req, resp);
+            verify(req, never()).setAttribute(eq(ATTR_ABAC_USERNAME), any());
+        }
+
+        @Test
+        @DisplayName("Use cahced username if available.")
+        void doFilter_cachedUsername() throws Exception {
+            // given
+            System.setProperty("ABAC_USERINFO_URL", baseUrl + "/userinfo"); // won't ever be called
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter(legacy);
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn("Bearer cachedtoken");
+
+            try (MockedStatic<io.telicent.jena.abac.core.AttributesStoreAuthServer> st =
+                         mockStatic(io.telicent.jena.abac.core.AttributesStoreAuthServer.class)) {
+                st.when(() -> io.telicent.jena.abac.core.AttributesStoreAuthServer.getCachedUsername("cachedtoken"))
+                        .thenReturn("bob");
+
+                // when
+                f.doFilter(req, resp, chain);
+
+                // then
+                verify(req).setAttribute(ATTR_ABAC_USERNAME, "bob");
+                verify(chain).doFilter(req, resp);
+                verifyNoInteractions(legacy);
+            }
+        }
+
+        // --------- No header: just continues ---------
+
+        @Test
+        @DisplayName("If no header, continue")
+        void doFilter_noBearerHeader_continues() throws Exception {
+            // given
+            System.setProperty("ABAC_USERINFO_URL", baseUrl + "/userinfo");
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter(legacy);
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn(null);
+
+            // when
+            f.doFilter(req, resp, chain);
+
+            // then
+            verify(chain).doFilter(req, resp);
+            verifyNoInteractions(legacy);
+        }
+
+        @Test
+        @DisplayName("Do not call if token blank")
+        void blankToken_continues() throws Exception {
+            // given
+            System.setProperty("ABAC_USERINFO_URL", baseUrl + "/userinfo");
+
+            AuthBearerFilter legacy = mock(AuthBearerFilter.class);
+            UserInfoEnrichmentFilter f = new UserInfoEnrichmentFilter(legacy);
+
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            ServletResponse resp = mock(ServletResponse.class);
+            FilterChain chain = mock(FilterChain.class);
+
+            when(req.getHeader(HttpNames.hAuthorization)).thenReturn("Bearer   ");
+
+            // when
+            f.doFilter(req, resp, chain);
+
+            // then
+            verify(chain).doFilter(req, resp);
+            verifyNoInteractions(legacy);
+        }
+    }
+
+    @Nested
+    public class flattenFromAttributesObjectTest {
+
+        @Test
+        @DisplayName("Flatten map for attributes - happy path")
+        void flattenFromAttributesObject_coversLegacyHelper() {
+            // given
+            String json = """
+                    {
+                      "dept":"eng",
+                      "clearance":["TS","S"],
+                      "flags":{"oncall":"true","mode":"blue"}
+                    }
+                    """;
+            JsonValue parsedJSON = parseAny(json);
+
+            // when
+            java.util.List<String> pairs = UserInfoEnrichmentFilter.flattenFromAttributesObject(parsedJSON);
+
+            // then
+            assertNotNull(pairs);
+            assertTrue(pairs.contains("dept=eng"));
+            assertTrue(pairs.contains("clearance=TS"));
+            assertTrue(pairs.contains("clearance=S"));
+            assertTrue(pairs.contains("flags.oncall=true"));
+            assertTrue(pairs.contains("flags.mode=blue"));
+        }
+
+        @Test
+        @DisplayName("Flatten map for attributes - null")
+        void flattenFromAttributesObject_null() {
+            // given
+            // wehn
+            // then
+            assertNull(UserInfoEnrichmentFilter.flattenFromAttributesObject(null));
+        }
+
+        @Test
+        @DisplayName("Flatten map for attributes - not JSON object")
+        void flattenFromAttributesObject_emptyString() {
+            // given
+            String json = "true";
+            JsonValue notObjectJson = parseAny(json);
+            // when, then
+            assertNull(UserInfoEnrichmentFilter.flattenFromAttributesObject(notObjectJson));
+        }
+
+        @Test
+        @DisplayName("Flatten map for attributes - emptyString")
+        void flattenFromAttributesObject_nullInternal() {
+            // given
+            JsonObject object = new JsonObject();
+            object.put("nullEntry", (JsonValue) null);
+
+            java.util.List<String> pairs = UserInfoEnrichmentFilter.flattenFromAttributesObject(object);
+            assertNotNull(pairs);
+            assertTrue(pairs.isEmpty());
+        }
+    }
+
+    @Nested
+    public class flattenToAttributeValueSetTest {
+        @Test
+        @DisplayName("Null returns empty")
+        void nullInput_returnsEmpty() {
+            // given
+            // when
+            AttributeValueSet out = UserInfoEnrichmentFilter.flattenToAttributeValueSet(null);
+            // then
+            assertNotNull(out);
+            assertTrue(out.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Test mix of entries")
+        void array_mixedEntries_parsedAndInvalidIgnored() {
+            // given
+            JsonValue v = parseAny("""
+                        ["dept=eng","not-a-pair","", "   ", "clearance=TS", 123, true, null]
+                    """);
+            // when
+            AttributeValueSet out = UserInfoEnrichmentFilter.flattenToAttributeValueSet(v);
+
+            // then
+            assertNotNull(out);
+            assertFalse(out.isEmpty());
+            assertTrue(hasAttributeValue(out, "dept", "eng"));
+            assertTrue(hasAttributeValue(out, "clearance", "TS"));
+
+            // Ensure only the valid pairs were added
+            // (size check is indirect since AttributeValueSet uses a multimap)
+            assertEquals(1, out.get(Attribute.create("dept")).size());
+            assertEquals(1, out.get(Attribute.create("clearance")).size());
+            // invalid/blank/non-string entries should not create attributes
+            assertFalse(out.hasAttribute(Attribute.create("not")));
+        }
+
+        // v is object: exercises processJsonObject path (scalars, arrays, nested objects)
+        @Test
+        @DisplayName("All supported types")
+        void object_deepFlatten_allSupportedTypes() {
+            // given
+            JsonValue v = parseAny("""
+                        {
+                          "dept": "eng",
+                          "clearance": ["TS","S"],
+                          "meta": {
+                            "oncall": true,
+                            "level": 3
+                          }
+                        }
+                    """);
+
+            // when
+            AttributeValueSet out = UserInfoEnrichmentFilter.flattenToAttributeValueSet(v);
+
+            // then
+            assertNotNull(out);
+            assertFalse(out.isEmpty());
+
+            // scalars
+            assertTrue(hasAttributeValue(out, "dept", "eng"));
+            // arrays
+            assertTrue(hasAttributeValue(out, "clearance", "TS"));
+            assertTrue(hasAttributeValue(out, "clearance", "S"));
+            // nested object scalars
+            assertTrue(hasAttributeValue(out, "meta.oncall", true));
+            assertTrue(hasAttributeValue(out, "meta.level", "3"));
+        }
+
+        @Test
+        @DisplayName("If not an object or array return empty")
+        void scalarInput_returnsEmpty() {
+            // given, when, then
+            JsonValue vTrue = parseAny("true");
+            AttributeValueSet outTrue = UserInfoEnrichmentFilter.flattenToAttributeValueSet(vTrue);
+            assertTrue(outTrue.isEmpty());
+
+            // given, when, then
+            JsonValue vNum = parseAny("123");
+            AttributeValueSet outNum = UserInfoEnrichmentFilter.flattenToAttributeValueSet(vNum);
+            assertTrue(outNum.isEmpty());
+
+            // given, when, then
+            JsonValue vStr = parseAny("\"dept=eng\"");
+            AttributeValueSet outStr = UserInfoEnrichmentFilter.flattenToAttributeValueSet(vStr);
+            assertTrue(outStr.isEmpty());
+        }
+    }
+
+    @Nested
+    public class testTryFields {
+
+        @Test
+        @DisplayName("Return first match")
+        void returnsFirstMatchImmediately() {
+            // given
+            JsonObject obj = parseAny("{\"a\":1, \"b\":\"x\"}").getAsObject();
+            // when
+            Optional<JsonValue> out = UserInfoEnrichmentFilter.tryFields(obj, List.of("a", "b"));
+            // then
+            assertTrue(out.isPresent());
+            assertTrue(out.get().isNumber());
+            assertEquals("1", out.get().getAsNumber().value().toString());
+        }
+
+        @Test
+        @DisplayName("Skip missing")
+        void skipsMissingAndFindsLaterField() {
+            // given
+            JsonObject obj = parseAny("{\"b\":\"x\"}").getAsObject();
+            // when
+            Optional<JsonValue> out = UserInfoEnrichmentFilter.tryFields(obj, List.of("a", "b"));
+            // then
+            assertTrue(out.isPresent());
+            assertTrue(out.get().isString());
+            assertEquals("x", out.get().getAsString().value());
+        }
+
+        @Test
+        @DisplayName("Return empty if no fields")
+        void returnsEmptyWhenNoFieldsPresent() {
+            // given
+            JsonObject obj = parseAny("{\"a\":1}").getAsObject();
+            // when
+            Optional<JsonValue> out = UserInfoEnrichmentFilter.tryFields(obj, List.of("z"));
+            // then
+            assertTrue(out.isEmpty());
+        }
+
+        @Test
+        void returnsEmptyWhenNamesListIsEmpty() {
+            //given
+            JsonObject obj = parseAny("{\"a\":1}").getAsObject();
+            // when
+            Optional<JsonValue> out = UserInfoEnrichmentFilter.tryFields(obj, List.of());
+            // then
+            assertTrue(out.isEmpty());
+        }
+
+        @Test
+        void returnsJsonNullIfFieldIsExplicitNull() {
+            // given
+            JsonObject obj = parseAny("{\"a\":null}").getAsObject();
+            // when
+            Optional<JsonValue> out = UserInfoEnrichmentFilter.tryFields(obj, List.of("a"));
+            // then
+            assertTrue(out.isPresent());
+            assertTrue(out.get().isNull());
+        }
+    }
+
+    @Nested
+    class processNestedObjectTest {
+
+        @Test
+        void arrayBranch_includingNestedArrayAndObject() {
+            // { "arr": ["A","B", true, 1, null, {"nested":"X"}, ["Y","Z"]] }
+            JsonObject obj = parseAny("""
+                        { "arr": ["A","B", true, 1, null, {"nested":"X"}, ["Y","Z"]] }
+                    """).getAsObject();
+
+            List<AttributeValue> out = new ArrayList<>();
+            UserInfoEnrichmentFilter.processNestedObject("p", obj, out);
+
+            Set<String> pairs = asPairs(out);
+            // Scalars inside array
+            assertTrue(pairs.contains("p.arr=A"));
+            assertTrue(pairs.contains("p.arr=B"));
+            assertTrue(pairs.contains("p.arr=true"));
+            assertTrue(pairs.contains("p.arr=1"));
+            // Nested object inside array -> prefix.field=value
+            assertTrue(pairs.contains("p.arr.nested=X"));
+            // Nested array inside array -> same base key
+            assertTrue(pairs.contains("p.arr=Y"));
+            assertTrue(pairs.contains("p.arr=Z"));
+            // JSON null inside array should not add anything — nothing to assert; presence above is sufficient.
+        }
+
+        @Test
+        void objectBranch_recursesIntoNestedObjects() {
+            // { "o": { "inner":"val", "deep": { "x": 2 } } }
+            JsonObject obj = parseAny("""
+                        { "o": { "inner":"val", "deep": { "x": 2 } } }
+                    """).getAsObject();
+
+            List<AttributeValue> out = new ArrayList<>();
+            UserInfoEnrichmentFilter.processNestedObject("p", obj, out);
+
+            Set<String> pairs = asPairs(out);
+            assertTrue(pairs.contains("p.o.inner=val"));
+            assertTrue(pairs.contains("p.o.deep.x=2"));
+        }
+
+        @Test
+        void scalarBranch_addsForStringBooleanNumber_ignoresJsonNull() {
+            // { "s":"str", "b": true, "n": 42, "nullv": null }
+            JsonObject obj = parseAny("""
+                        { "s":"str", "b": true, "n": 42, "nullv": null }
+                    """).getAsObject();
+
+            List<AttributeValue> out = new ArrayList<>();
+            UserInfoEnrichmentFilter.processNestedObject("p", obj, out);
+
+            Set<String> pairs = asPairs(out);
+            assertTrue(pairs.contains("p.s=str"));
+            assertTrue(pairs.contains("p.b=true"));
+            assertTrue(pairs.contains("p.n=42"));
+            // Explicit JSON null is not a scalar (string/number/boolean) for our converter -> should not be present
+            assertFalse(pairs.contains("p.nullv=")); // sanity check; exact "null" won't be added either
+            assertFalse(pairs.stream().anyMatch(s -> s.startsWith("p.nullv=")));
+        }
+    }
+
+    @Nested
+    public class parseValueTest {
+        @Test
+        @DisplayName("parse invalid value")
+        void test_invalidValue() {
+            // given
+            // when
+            // then
+            assertNull(UserInfoEnrichmentFilter.parseValue("ru!bbXish"));
+        }
+    }
+
+    @Nested
+    public class jsonScalarAsStringTest {
+        @Test
+        @DisplayName("")
+        void test_nullValue() {
+            // given
+            // when
+            // then
+            assertNull(UserInfoEnrichmentFilter.jsonScalarAsString(null));
+        }
+    }
+
+    private static void setResponse(com.sun.net.httpserver.HttpExchange ex, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes();
+        ex.getResponseHeaders().add("Content-Type", "application/json");
+        ex.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private static void assertAuthorization(com.sun.net.httpserver.HttpExchange ex, String expected) {
+        String got = ex.getRequestHeaders().getFirst("Authorization");
+        if (got == null || !got.equals(expected)) {
+            throw new AssertionError("Expected Authorization '" + expected + "', got '" + got + "'");
+        }
+    }
+
+    private static boolean hasAttributeValue(AttributeValueSet set, String attribute, String value) {
+        return set.get(Attribute.create(attribute)).contains(ValueTerm.value(value));
+    }
+
+    private static boolean hasAttributeValue(AttributeValueSet set, String attribute, Boolean value) {
+        return set.get(Attribute.create(attribute)).contains(ValueTerm.value(value));
+    }
+
+
+    /**
+     * Convert produced AttributeValues to "attr=value" strings for easy assertions.
+     */
+    private static Set<String> asPairs(List<AttributeValue> out) {
+        return out.stream()
+                .map(av -> av.attribute().name() + "=" + av.value().asString())
+                .collect(Collectors.toSet());
+    }
+
+}


### PR DESCRIPTION
And optionally Hierarchy data that can be in a file (in the format expected for Local Attribute Store) or an endpoint (similar to that from the Remote Attributes Store) or not at all. 

The server can run in one of three modes: 
- new (the new Auth Server approach)
- legacy (the previous approach)
- hybrid (that combines both the old and new)

In Hybrid, we will attempt to look-up against the Auth Server and if that fails we use the previous approach. This appraoch allows us to have multiple datasets covering the various options.

Assumptions are also being made on the format of the ABAC attributes - from the attributes column from the users table in Auth Server. It will try to process the attributes in any case. 
```json
{
  "fullName": "Paul Gallagher",
  "lastName": "Gallagher",
  "firstName": "Paul",
  "abac_attributes": {
    "retired": true,
    "everyone": "true",
    "familyRole": "matriarch",
    "nationality": " british"
  }
}
```

Another PR - in the Auth Server repo; will follow that implements a hierarchy endpoint solution that we may wish to adopt going forward. 