### PR TITLE
Make Fuseki operation constants public (CORE-962)

### DIFF
--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/ServerABAC.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/ServerABAC.java
@@ -33,7 +33,10 @@ import static io.telicent.jena.abac.fuseki.server.UserInfoEnrichmentFilter.ATTR_
 
 public class ServerABAC {
 
-    static class Vocab {
+    /**
+     * Provides constants relating to custom ABAC operations for Fuseki that this module implements
+     */
+    public static class Vocab {
         // These operations directly apply the ABAC-versions of the processors.
         // FMod_ABAC also replaces the processor for the usual "fuseki:query" etc. operations.
 


### PR DESCRIPTION
Needed in order to allow other libraries to refer to and match against these custom operations.

# Related Issues

- Needed to allow CORE-962 work on telicent-oss/smart-cache-graph to automatically generate authorisation policy based upon configured Fuseki operations correctly