### PR TITLE
Create a JUnit Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "weekly"
       day: monday
     groups:
+      # Always group JUnit depenendencies together in their own PRs as these typically need to be updated together
+      junit:
+        patterns:
+          - "org.junit.jupiter"
+          - "org.junit.vintage"
+          - "org.junit.platform"
+          - "org.junit"
       patches:
         update-types:
           - "minor"


### PR DESCRIPTION
JUnit dependencies need to be updated together, even when there's a major version bump, otherwise we end up with PRs that can't be applied (e.g. see #142 and #143) as the various JUnit dependencies aren't in lockstep