### PR TITLE
Attempt JUnit Dependabot group again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,11 @@ updates:
       # Always group JUnit depenendencies together in their own PRs as these typically need to be updated together
       junit:
         patterns:
-          - "org.junit.jupiter"
-          - "org.junit.vintage"
-          - "org.junit.platform"
-          - "org.junit"
+          - "org.junit.jupiter:*"
+          - "org.junit.vintage:*"
+          - "org.junit.platform:*"
+          - "org.junit:*"
+      # Group together minor and patch version updates
       patches:
         update-types:
           - "minor"


### PR DESCRIPTION
updater | 2025/10/07 09:29:33 WARN <job_1119459339> Please check your configuration as there are groups where no dependencies match:
- junit

While my previous PR looked perfectly plausible apparently the syntax was not correct:

```
This can happen if:
- the group's 'pattern' rules are misspelled
- your configuration's 'allow' rules do not permit any of the dependencies that match the group
- the dependencies that match the group rules have been removed from your project

  proxy | 2025/10/07 09:29:33 [008] POST /update_jobs/1119459339/update_dependency_list
  proxy | 2025/10/07 09:29:33 [008] 204 /update_jobs/1119459339/update_dependency_list
  proxy | 2025/10/07 09:29:33 [010] POST /update_jobs/1119459339/increment_metric
  proxy | 2025/10/07 09:29:33 [010] 204 /update_jobs/1119459339/increment_metric
updater | 2025/10/07 09:29:33 INFO <job_1119459339> Starting grouped update job for telicent-oss/rdf-abac
2025/10/07 09:29:33 INFO <job_1119459339> Found 2 group(s).
updater | 2025/10/07 09:29:33 WARN <job_1119459339> Skipping update group for 'junit' as it does not match any allowed dependencies.
updater | 2025/10/07 09:29:33 INFO <job_1119459339> Marking group 'junit' as handled.
```

I can't find any good examples of this style of Dependency pattern matching so trying what seems plausible based on the documentation to see if that fixes the grouping.