### PR TITLE
CORE-1149: integrating DictionaryLabelStore for RocksDB labels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <!-- Internal dependencies -->
     <dependency.jena>6.0.0</dependency.jena>
     <dependency.rocksdb>10.2.1</dependency.rocksdb>
+    <dependency.smart-caches.storage>0.8.1-SNAPSHOT</dependency.smart-caches.storage>
 
     <!-- External dependencies -->
     <dependency.assert>3.27.7</dependency.assert>

--- a/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/BenchmarkBase.java
+++ b/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/BenchmarkBase.java
@@ -1,0 +1,51 @@
+package io.telicent.jena.abac.labels;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+abstract class BenchmarkBase {
+
+    private static final int MAX_LABELS_PER_TRIPLE = 8;
+    private static final int LABEL_TEXT_LENGTH = 32;
+    static final int SUBJECT_CARDINALITY = 10_000;
+    static final int PREDICATE_CARDINALITY = 32;
+
+    Random random;
+
+    /**
+     * Generate a reproducible SPO triple for index {@code i}.
+     * The pattern ensures:
+     *  - many distinct objects
+     *  - repeated subjects/predicates (more realistic index behaviour)
+     */
+    Triple generateDataTriple(int i) {
+        final int sIndex = i % SUBJECT_CARDINALITY;
+        final int pIndex = i % PREDICATE_CARDINALITY;
+        final Node s = NodeFactory.createURI("http://example.org/s/" + sIndex);
+        final Node p = NodeFactory.createURI("http://example.org/p/" + pIndex);
+        final Node o = NodeFactory.createLiteralString("o-" + i);
+        return Triple.create(s, p, o);
+    }
+
+    /**
+     * Generate a small set of random label strings.
+     * Using Label.fromText() ensures the full label machinery is exercised
+     * (validation, AttributeExpr parsing, etc.).
+     */
+    List<Label> generateRandomLabels() {
+        final int numLabels = 1 + random.nextInt(MAX_LABELS_PER_TRIPLE);
+        final List<Label> labels = new ArrayList<>(numLabels);
+        for (int i = 0; i < numLabels; i++) {
+            final String text = RandomStringUtils.insecure()
+                    .nextAlphanumeric(LABEL_TEXT_LENGTH);
+            labels.add(Label.fromText(text));
+        }
+        return labels;
+    }
+}

--- a/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/DictionaryLabelsStoreBenchmark.java
+++ b/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/DictionaryLabelsStoreBenchmark.java
@@ -214,7 +214,7 @@ public class DictionaryLabelsStoreBenchmark extends BenchmarkBase {
 
     /** Generate unique triples for writing */
     private Triple generateWriteTriple(int i) {
-        return generateDataTriple(tripleCount + 1);
+        return generateDataTriple(tripleCount + i);
     }
 
 }

--- a/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/DictionaryLabelsStoreBenchmark.java
+++ b/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/DictionaryLabelsStoreBenchmark.java
@@ -1,0 +1,220 @@
+package io.telicent.jena.abac.labels;
+
+import io.telicent.smart.cache.storage.labels.DictionaryLabelsStore;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JMH benchmarks comparing RocksDB label store performance with and without
+ * a DictionaryLabelsStore for compact label encoding.
+ * <p>
+ * The dictionary maps label strings to integer IDs, reducing storage size
+ * and potentially improving read performance at the cost of an extra
+ * lookup/encoding step on writes.
+ * <p>
+ * Benchmarks:
+ *  - read_hits_plain:       100% hits, RocksDB without dictionary
+ *  - read_hits_dictionary:  100% hits, RocksDB with dictionary
+ *  - read_mixed_plain:      50% hits / 50% misses, RocksDB without dictionary
+ *  - read_mixed_dictionary: 50% hits / 50% misses, RocksDB with dictionary
+ *  - write_plain:           bulk writes, RocksDB without dictionary
+ *  - write_dictionary:      bulk writes, RocksDB with dictionary
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+public class DictionaryLabelsStoreBenchmark extends BenchmarkBase {
+
+    /**
+     * Number of SPO triples preloaded into each store.
+     */
+    @Param({"100000", "1000000"})
+    public int tripleCount;
+
+    /**
+     * Number of read operations per benchmark invocation.
+     * Reported score is "ms per N lookups".
+     */
+    @Param({"1000000"})
+    public int readsPerInvocation;
+
+    /**
+     * Number of write operations per benchmark invocation.
+     */
+    @Param({"100000"})
+    public int writesPerInvocation;
+
+    private LabelsStoreRocksDB plainStore;
+    private LabelsStoreRocksDB dictionaryStore;
+
+    private Triple[] hitTriples;
+    private Triple[] mixedTriples;
+    private Triple[] writeTriples;
+    private List<Label>[] writeLabels;
+
+
+    @Setup(Level.Trial)
+    public void setUp() throws IOException {
+        random = new Random(42L);
+
+        // Plain RocksDB store (no dictionary)
+        final File plainDir = Files.createTempDirectory("labels-jmh-plain").toFile();
+        plainDir.deleteOnExit();
+        final RocksDBHelper plainHelper = new RocksDBHelper();
+        final StoreFmt storeFmt = new StoreFmtByString();
+        plainStore = new LabelsStoreRocksDB(
+                plainHelper,
+                plainDir,
+                storeFmt,
+                LabelsStoreRocksDB.LabelMode.Overwrite,
+                null
+        );
+
+        // RocksDB store with DictionaryLabelsStore
+        final File dictionaryDir = Files.createTempDirectory("labels-jmh-dictionary").toFile();
+        dictionaryDir.deleteOnExit();
+        final File dictionarySubDir = new File(dictionaryDir, "dictionary");
+        dictionarySubDir.mkdirs();
+        final RocksDBHelper dictionaryHelper = new RocksDBHelper();
+        final DictionaryLabelsStore dictionaryLabelsStore = Labels.createDictionaryLabelsStore(
+                dictionarySubDir, Labels.DEFAULT_DICTIONARY_CACHE_SIZE
+        );
+        dictionaryStore = new LabelsStoreRocksDB(
+                dictionaryHelper,
+                dictionaryDir,
+                storeFmt,
+                LabelsStoreRocksDB.LabelMode.Overwrite,
+                null,
+                dictionaryLabelsStore
+        );
+
+        // Pre-generate and load triples into both stores
+        hitTriples = new Triple[tripleCount];
+        for (int i = 0; i < tripleCount; i++) {
+            Triple t = generateDataTriple(i);
+            hitTriples[i] = t;
+
+            List<Label> labels = generateRandomLabels();
+            plainStore.add(t, labels);
+            dictionaryStore.add(t, labels);
+        }
+
+        // Prepare mixed workload: 50% hits, 50% misses
+        mixedTriples = new Triple[readsPerInvocation];
+        for (int i = 0; i < readsPerInvocation; i++) {
+            if ((i & 1) == 0) {
+                mixedTriples[i] = hitTriples[i % tripleCount];
+            } else {
+                int idx = i % tripleCount;
+                Triple base = hitTriples[idx];
+                Node s = base.getSubject();
+                Node p = base.getPredicate();
+                Node oMiss = NodeFactory.createLiteralString("missing-object-" + idx);
+                mixedTriples[i] = Triple.create(s, p, oMiss);
+            }
+        }
+
+        // Pre-generate write workload (triples that don't exist in the stores yet)
+        @SuppressWarnings("unchecked")
+        List<Label>[] labelsArr = new List[writesPerInvocation];
+        writeLabels = labelsArr;
+        writeTriples = new Triple[writesPerInvocation];
+        for (int i = 0; i < writesPerInvocation; i++) {
+            writeTriples[i] = generateWriteTriple(i);
+            writeLabels[i] = generateRandomLabels();
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (plainStore != null) {
+            plainStore.close();
+        }
+        if (dictionaryStore != null) {
+            dictionaryStore.close();
+        }
+        plainStore = null;
+        dictionaryStore = null;
+        hitTriples = null;
+        mixedTriples = null;
+        writeTriples = null;
+        writeLabels = null;
+    }
+
+    // ---- Read benchmarks: 100% hits ----
+
+    @Benchmark
+    public void read_hits_plain(Blackhole bh) {
+        for (int i = 0; i < readsPerInvocation; i++) {
+            Triple t = hitTriples[i % tripleCount];
+            List<Label> labels = plainStore.labelsForTriples(t);
+            bh.consume(labels);
+        }
+    }
+
+    @Benchmark
+    public void read_hits_dictionary(Blackhole bh) {
+        for (int i = 0; i < readsPerInvocation; i++) {
+            Triple t = hitTriples[i % tripleCount];
+            List<Label> labels = dictionaryStore.labelsForTriples(t);
+            bh.consume(labels);
+        }
+    }
+
+    // ---- Read benchmarks: 50% hits, 50% misses ----
+
+    @Benchmark
+    public void read_mixed_plain(Blackhole bh) {
+        for (int i = 0; i < readsPerInvocation; i++) {
+            Triple t = mixedTriples[i];
+            List<Label> labels = plainStore.labelsForTriples(t);
+            bh.consume(labels);
+        }
+    }
+
+    @Benchmark
+    public void read_mixed_dictionary(Blackhole bh) {
+        for (int i = 0; i < readsPerInvocation; i++) {
+            Triple t = mixedTriples[i];
+            List<Label> labels = dictionaryStore.labelsForTriples(t);
+            bh.consume(labels);
+        }
+    }
+
+    // ---- Write benchmarks ----
+
+    @Benchmark
+    public void write_plain(Blackhole bh) {
+        for (int i = 0; i < writesPerInvocation; i++) {
+            plainStore.add(writeTriples[i], writeLabels[i]);
+            bh.consume(i);
+        }
+    }
+
+    @Benchmark
+    public void write_dictionary(Blackhole bh) {
+        for (int i = 0; i < writesPerInvocation; i++) {
+            dictionaryStore.add(writeTriples[i], writeLabels[i]);
+            bh.consume(i);
+        }
+    }
+
+    /** Generate unique triples for writing */
+    private Triple generateWriteTriple(int i) {
+        return generateDataTriple(tripleCount + 1);
+    }
+
+}

--- a/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDBBaselineBenchmark.java
+++ b/rdf-abac-benchmark/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDBBaselineBenchmark.java
@@ -1,6 +1,5 @@
 package io.telicent.jena.abac.labels;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
@@ -10,7 +9,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-public class LabelsStoreRocksDBBaselineBenchmark {
+public class LabelsStoreRocksDBBaselineBenchmark extends BenchmarkBase {
 
     /**
      * Number of SPO triples to load into the label store.
@@ -52,13 +50,6 @@ public class LabelsStoreRocksDBBaselineBenchmark {
 
     private Triple[] hitTriples;
     private Triple[] mixedTriples;
-
-    private Random random;
-
-    private static final int SUBJECT_CARDINALITY = 10_000;
-    private static final int PREDICATE_CARDINALITY = 32;
-    private static final int MAX_LABELS_PER_TRIPLE = 8;
-    private static final int LABEL_TEXT_LENGTH = 32;
 
     @Setup(Level.Trial)
     public void setUp() throws IOException {
@@ -148,35 +139,4 @@ public class LabelsStoreRocksDBBaselineBenchmark {
         }
     }
 
-    /**
-     * Generate a reproducible SPO triple for index {@code i}.
-     * The pattern ensures:
-     *  - many distinct objects
-     *  - repeated subjects/predicates (more realistic index behaviour)
-     */
-    private Triple generateDataTriple(int i) {
-        int sIndex = i % SUBJECT_CARDINALITY;
-        int pIndex = i % PREDICATE_CARDINALITY;
-        int oIndex = i;
-        Node s = NodeFactory.createURI("http://example.org/s/" + sIndex);
-        Node p = NodeFactory.createURI("http://example.org/p/" + pIndex);
-        Node o = NodeFactory.createLiteralString("o-" + oIndex);
-        return Triple.create(s, p, o);
-    }
-
-    /**
-     * Generate a small set of random label strings.
-     * Using Label.fromText() ensures the full label machinery is exercised
-     * (validation, AttributeExpr parsing, etc.).
-     */
-    private List<Label> generateRandomLabels() {
-        int numLabels = 1 + random.nextInt(MAX_LABELS_PER_TRIPLE);
-        List<Label> labels = new ArrayList<>(numLabels);
-        for (int i = 0; i < numLabels; i++) {
-            String text = RandomStringUtils.insecure()
-                    .nextAlphanumeric(LABEL_TEXT_LENGTH);
-            labels.add(Label.fromText(text));
-        }
-        return labels;
-    }
 }

--- a/rdf-abac-core/pom.xml
+++ b/rdf-abac-core/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>apache-jena-libs</artifactId>
       <type>pom</type>
     </dependency>
+    <dependency>
+      <groupId>io.telicent.smart-caches.storage</groupId>
+      <artifactId>label-store-rocksdb</artifactId>
+      <version>${dependency.smart-caches.storage}</version>
+    </dependency>
 
     <!-- External dependencies -->
     <dependency>

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/assembler/LabelStoreAssembler.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/assembler/LabelStoreAssembler.java
@@ -218,12 +218,14 @@ public class LabelStoreAssembler {
      * @throws RocksDBException if something goes wrong during database creation
      */
     static LabelsStore generateStore(File dbDirectory, Resource resource) throws RocksDBException {
-        LabelMode labelMode = getLabelMode(resource);
-        StoreFmt storageFmt = getStorageFormat(resource);
-        DictionaryLabelsStore dictStore = getDictionaryStore(dbDirectory, resource);
-        if (dictStore != null) {
-            return Labels.createLabelsStoreRocksDB(dbDirectory, labelMode, resource, storageFmt, dictStore);
+        final LabelMode labelMode = getLabelMode(resource);
+        final StoreFmt storageFmt = getStorageFormat(resource);
+        final DictionaryLabelsStore dictionaryStore = getDictionaryStore(dbDirectory, resource);
+        if (dictionaryStore != null) {
+            FmtLog.info(Secured.BUILD_LOG, "Creating RocksDB label store with dictionary encoding of labels");
+            return Labels.createLabelsStoreRocksDB(dbDirectory, labelMode, resource, storageFmt, dictionaryStore);
         }
+        FmtLog.info(Secured.BUILD_LOG, "Create RocksDB label store without dictionary");
         return Labels.createLabelsStoreRocksDB(dbDirectory, labelMode, resource, storageFmt);
     }
 

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/VocabAuthzDataset.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/VocabAuthzDataset.java
@@ -120,6 +120,7 @@ public class VocabAuthzDataset {
     public static Property pLabelsStoreUpdateModeMerge = ResourceFactory.createProperty(NS+"labelsStoreUpdateModeMerge");
     public static Property pLabelsStoreByteBufferSize = ResourceFactory.createProperty(NS+"labelsStoreByteBufferSize");
     public static Property pLabelsStoreByHashFunction = ResourceFactory.createProperty(NS+"labelsStoreByHashFunction");
+    public static Property pLabelsStoreWithDictionary = ResourceFactory.createProperty(NS+"labelsStoreWithDictionary");
 
     // -- Dataset attribute settings.
 

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/LabelsStoreRocksDB.java
@@ -99,7 +99,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
             @Override
             public void writeUsingMode(TransactionalRocksDB transactionalRocksDB, ColumnFamilyHandle columnFamilyHandle, ByteBuffer key,
                                        ByteBuffer value) {
-                if ( LOG.isDebugEnabled() ) {
+                if (LOG.isDebugEnabled()) {
                     keyTotalSize.addAndGet(key.limit());
                     valueTotalSize.addAndGet(value.limit());
                 }
@@ -110,7 +110,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
             @Override
             public void writeUsingMode(TransactionalRocksDB transactionalRocksDB, ColumnFamilyHandle columnFamilyHandle, ByteBuffer key,
                                        ByteBuffer value) {
-                if ( LOG.isDebugEnabled() ) {
+                if (LOG.isDebugEnabled()) {
                     keyTotalSize.addAndGet(key.limit());
                     valueTotalSize.addAndGet(value.limit());
                 }
@@ -164,7 +164,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
      * round-tripform 0.12345679"^^xsd:float due to the precision of float values.
      * Precision also affects xsd:double.
      */
-    private static final Function<Node,Node> normalizeFunction = NormalizeTermsTDB2::normalizeTDB2;
+    private static final Function<Node, Node> normalizeFunction = NormalizeTermsTDB2::normalizeTDB2;
 
     /**
      * Optional dictionary for label encoding. When non-null, labels are stored as
@@ -195,7 +195,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
     /**
      * The single key used in the wildcard column family is the byte 0xa
      */
-    protected final static ByteBuffer KEY_cfh___ = ByteBuffer.allocateDirect(1).put((byte)0xa).flip();
+    protected final static ByteBuffer KEY_cfh___ = ByteBuffer.allocateDirect(1).put((byte) 0xa).flip();
 
     private ByteBuffer allocateKVBuffer() {
         return ByteBuffer.allocateDirect(bufferCapacity).order(ByteOrder.LITTLE_ENDIAN);
@@ -204,13 +204,17 @@ public class LabelsStoreRocksDB implements LabelsStore {
     // Cached parsing on attribute expressions.
     // Use a small cache to cover the common case of all the labels being the same.
     private final static Cache<String, AttributeExpr> cache = CacheFactory.createOneSlotCache();
-    /** Parse an attribute expressions - a label */
+
+    /**
+     * Parse an attribute expressions - a label
+     */
     private static AttributeExpr parseAttrExpr(String str) {
         return cache.get(str, AE::parseExpr);
     }
 
     /**
      * Obtain the byte buffer capacity value from configuration if available.
+     *
      * @param resource RDF Node representing the configuration
      */
     private static int getByteBufferSize(Resource resource) {
@@ -233,8 +237,8 @@ public class LabelsStoreRocksDB implements LabelsStore {
     /**
      * Create a RocksDB-based label store
      *
-     * @param dbRoot file into which to save the database
-     * @param storeFmt formatter to transform node(s) into byte arrays.
+     * @param dbRoot    file into which to save the database
+     * @param storeFmt  formatter to transform node(s) into byte arrays.
      * @param labelMode whether to overwrite or merge when updating entries.
      */
     /* package */ LabelsStoreRocksDB(final RocksDBHelper helper, final File dbRoot, final StoreFmt storeFmt, final LabelMode labelMode, Resource resource) {
@@ -244,9 +248,9 @@ public class LabelsStoreRocksDB implements LabelsStore {
     /**
      * Create a RocksDB-based label store with optional dictionary-based label encoding.
      *
-     * @param dbRoot file into which to save the database
-     * @param storeFmt formatter to transform node(s) into byte arrays.
-     * @param labelMode whether to overwrite or merge when updating entries.
+     * @param dbRoot                file into which to save the database
+     * @param storeFmt              formatter to transform node(s) into byte arrays.
+     * @param labelMode             whether to overwrite or merge when updating entries.
      * @param dictionaryLabelsStore optional dictionary for mapping labels to compact integer IDs.
      */
     /* package */ LabelsStoreRocksDB(final RocksDBHelper helper, final File dbRoot, final StoreFmt storeFmt,
@@ -283,7 +287,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
     @Override
     public List<Label> labelsForTriples(Triple triple) {
         triple = tripleNormalize(triple);
-        return tripleLabelCache.get(triple, t->labelsForTriples(t.getSubject(), t.getPredicate(), t.getObject()));
+        return tripleLabelCache.get(triple, t -> labelsForTriples(t.getSubject(), t.getPredicate(), t.getObject()));
     }
 
     // Convert a triple so that nulls become ANY and object literals are normalized.
@@ -292,15 +296,14 @@ public class LabelsStoreRocksDB implements LabelsStore {
         Node s = nullToAny(triple.getSubject());
         Node p = nullToAny(triple.getPredicate());
         Node o = nullToAny(triple.getObject());
-        if ( normalizeFunction != null ) {
+        if (normalizeFunction != null) {
             o = normalizeFunction.apply(o);
         }
-        if ( s == triple.getSubject() && p == triple.getPredicate() && o == triple.getObject() ) {
+        if (s == triple.getSubject() && p == triple.getPredicate() && o == triple.getObject()) {
             return triple;
         }
         return Triple.create(s, p, o);
     }
-
 
 
     /**
@@ -313,14 +316,14 @@ public class LabelsStoreRocksDB implements LabelsStore {
      * object) - fourth, _P_ (a wildcard for subject and object) - fifth, a complete
      * wildcard/backstop list of values.
      *
-     * @param subject part of the triple
+     * @param subject   part of the triple
      * @param predicate part of the triple
-     * @param object part of the triple
+     * @param object    part of the triple
      * @return a list/set of labels
      */
     private List<Label> labelsForTriples(final Node subject, final Node predicate, final Node object) {
         var pattern = ABACPattern.fromTriple(subject, predicate, object);
-        if ( pattern != ABACPattern.PatternSPO ) {
+        if (pattern != ABACPattern.PatternSPO) {
             var msg = "Asked for labels for a triple with wildcards: " + NodeFmtLib.displayStr(Triple.create(subject, predicate, object));
             throw new IllegalArgumentException(msg);
         }
@@ -334,7 +337,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
 
     @Override
     public void forEach(BiConsumer<Triple, List<Label>> action) {
-        throw new NotImplemented(this.getClass().getSimpleName()+".forEach");
+        throw new NotImplemented(this.getClass().getSimpleName() + ".forEach");
     }
 
     /**
@@ -352,7 +355,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
      * concatenation.
      *
      * @param valueBuffer holding the labels
-     * @param labels list which is to receive the final set of labels
+     * @param labels      list which is to receive the final set of labels
      * @return the list of labels, which contains a set of labels
      */
     private List<Label> getLabels(final ByteBuffer valueBuffer, final List<Label> labels) {
@@ -426,9 +429,9 @@ public class LabelsStoreRocksDB implements LabelsStore {
      * order not to destroy performance.
      * </p>
      *
-     * @param subject part of the triple
+     * @param subject   part of the triple
      * @param predicate part of the triple
-     * @param object part of the triple
+     * @param object    part of the triple
      * @return a list/set of labels
      * @throws RocksDBException if something went wrong with the database lookup
      */
@@ -450,7 +453,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
         }
 
         // No pattern support
-        if ( ! patternsLoaded )
+        if (!patternsLoaded)
             return List.of();
 
         key.clear();
@@ -528,7 +531,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
         Node s = nullToAny(triple.getSubject());
         Node p = nullToAny(triple.getPredicate());
         Node o = nullToAny(triple.getObject());
-        if ( s == triple.getSubject() && p == triple.getPredicate() && o == triple.getObject() )
+        if (s == triple.getSubject() && p == triple.getPredicate() && o == triple.getObject())
             return triple;
         return Triple.create(s, p, o);
     }
@@ -536,27 +539,27 @@ public class LabelsStoreRocksDB implements LabelsStore {
     /**
      * Add (or replace) an entry to the labels store keyed by a triple S,P,O
      *
-     * @param subject part of the triple
+     * @param subject  part of the triple
      * @param property part of the triple
-     * @param object part of the triple
-     * @param labels to associate with the supplied triple
+     * @param object   part of the triple
+     * @param labels   to associate with the supplied triple
      */
     @Override
     public void add(Node subject, Node property, Node object, List<Label> labels) {
-        add(Triple.create(subject,property,object), labels);
+        add(Triple.create(subject, property, object), labels);
     }
 
     /**
      * Perform the code of adding a rule by deciding which pattern and column family
      * to write to. This is the single place that all updates happen.
      *
-     * @param subject part of the triple
+     * @param subject  part of the triple
      * @param property part of the triple
-     * @param object part of the triple
-     * @param labels to associate with the supplied triple
+     * @param object   part of the triple
+     * @param labels   to associate with the supplied triple
      */
     private void addRule(final Node subject, final Node property, /*final*/ Node object, final List<Label> labels) {
-        if ( normalizeFunction != null ) {
+        if (normalizeFunction != null) {
             object = normalizeFunction.apply(object);
         }
         addRuleWorker(subject, property, object, labels);
@@ -565,19 +568,19 @@ public class LabelsStoreRocksDB implements LabelsStore {
     private void addRuleWorker(final Node subject, final Node property, final Node object, final List<Label> labels) {
 
         // Single point for all adding to the labels store.
-        if ( rocksDB == null ) {
+        if (rocksDB == null) {
             throw new RuntimeException("The RocksDB labels store appears to be closed.");
         }
         LOG.debug("addRule ({},{},{}) -> {}", subject, property, object, labels);
 
-        if ( true ) {
+        if (true) {
             // Pattern disabled.
             // The machinery does support patterns but the feature is disabled pending reconsideration.
-            if ( !subject.isConcrete() || !property.isConcrete() || !object.isConcrete() ) {
+            if (!subject.isConcrete() || !property.isConcrete() || !object.isConcrete()) {
                 String msg = String.format("Unsupported: triple pattern: %s %s %s",
-                                           NodeFmtLib.strTTL(subject),
-                                           NodeFmtLib.strTTL(property),
-                                           NodeFmtLib.strTTL(object));
+                        NodeFmtLib.strTTL(subject),
+                        NodeFmtLib.strTTL(property),
+                        NodeFmtLib.strTTL(object));
             }
         }
 
@@ -593,16 +596,16 @@ public class LabelsStoreRocksDB implements LabelsStore {
         }
         counts[pattern.ordinal()] += 1;
         var isPattern = pattern != ABACPattern.PatternSPO;
-        if ( isPattern )
+        if (isPattern)
             this.patternsLoaded = true;
     }
 
     /**
      * Add a rule for a specific SPO to the SPO column family
      *
-     * @param subject part of the triple
-     * @param predicate part of the triple
-     * @param object part of the triple
+     * @param subject    part of the triple
+     * @param predicate  part of the triple
+     * @param object     part of the triple
      * @param labelsList to associate with the supplied triple
      */
     private void addRuleSPO(final Node subject, final Node predicate, final Node object, final List<Label> labelsList) {
@@ -616,8 +619,8 @@ public class LabelsStoreRocksDB implements LabelsStore {
     /**
      * Add a rule for SPAny to the SPO column family
      *
-     * @param subject part of the triple
-     * @param predicate part of the triple
+     * @param subject    part of the triple
+     * @param predicate  part of the triple
      * @param labelsList to associate with the supplied triple
      */
     private void addRuleSP_(final Node subject, final Node predicate, final List<Label> labelsList) {
@@ -631,7 +634,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
     /**
      * Add a rule for *P* to the predicate-only rules column family
      *
-     * @param predicate part of the triple
+     * @param predicate  part of the triple
      * @param labelsList to associate with the supplied predicate
      */
     private void addRule_P_(Node predicate, final List<Label> labelsList) {
@@ -645,7 +648,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
     /**
      * Add a rule for S** to the subject-only rules column family
      *
-     * @param subject part of the triple
+     * @param subject    part of the triple
      * @param labelsList to associate with the supplied subject
      */
     private void addRuleS__(Node subject, final List<Label> labelsList) {
@@ -702,11 +705,11 @@ public class LabelsStoreRocksDB implements LabelsStore {
 
         properties.put("approxsize", "" + approximateSizes());
         properties.put("size", "" + expensiveCount());
-        for ( ABACPattern pattern : ABACPattern.values() ) {
+        for (ABACPattern pattern : ABACPattern.values()) {
             properties.put("count" + pattern, "" + counts[pattern.ordinal()]);
         }
 
-        if ( LOG.isDebugEnabled() ) {
+        if (LOG.isDebugEnabled()) {
             properties.put("keyTotalSize", "" + keyTotalSize.get());
             properties.put("valueTotalSize", "" + valueTotalSize.get());
         }
@@ -724,32 +727,32 @@ public class LabelsStoreRocksDB implements LabelsStore {
     private long approximateSizes() {
         var first = new byte[0];
         var last = new byte[16];
-        Arrays.fill(last, (byte)0xff);
+        Arrays.fill(last, (byte) 0xff);
 
         long sizes = 0;
         sizes += getApproximateSize(cfhSPO, first, last);
         sizes += getApproximateSize(cfhS__, first, last);
         sizes += getApproximateSize(cfh_P_, first, last);
         var afterCFH___ = new byte[1];
-        afterCFH___[0] = (byte)(KEY_cfh___.get(0) + 1);
+        afterCFH___[0] = (byte) (KEY_cfh___.get(0) + 1);
         sizes += getApproximateSize(cfh___, new byte[0], afterCFH___);
 
         return sizes;
     }
 
     /**
-     * @param cfh column family to get size of
+     * @param cfh   column family to get size of
      * @param first must be a logically valid key in the keys of cfh (doesn't have to
-     *     be in the store)
-     * @param last must be a logically valid key in the keys of cfh (doesn't have to
-     *     be in the store)
+     *              be in the store)
+     * @param last  must be a logically valid key in the keys of cfh (doesn't have to
+     *              be in the store)
      * @return a number representing an approximate size (the best effort)
      */
     private long getApproximateSize(ColumnFamilyHandle cfh, byte[] first, byte[] last) {
         final long[] sizes = rocksDB.getApproximateSizes(cfh, List.of(new Range(new Slice(first), new Slice(last))),
-                                                    SizeApproximationFlag.INCLUDE_FILES, SizeApproximationFlag.INCLUDE_MEMTABLES);
+                SizeApproximationFlag.INCLUDE_FILES, SizeApproximationFlag.INCLUDE_MEMTABLES);
 
-        if ( sizes.length != 1 ) {
+        if (sizes.length != 1) {
             throw new RuntimeException("Unexpected size range of RocksDB column family: " + sizes.length);
         }
         return sizes[0];
@@ -757,7 +760,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
 
     private long expensiveCount() {
         var count = 0;
-        for ( var cfh : List.of(cfhSPO, cfhS__, cfh_P_, cfh___) ) {
+        for (var cfh : List.of(cfhSPO, cfhS__, cfh_P_, cfh___)) {
             count += getExpensiveCount(cfh);
         }
         return count;
@@ -766,7 +769,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
     private int getExpensiveCount(ColumnFamilyHandle cfh) {
         try (var it = rocksDB.newIterator(cfh)) {
             var count = 0;
-            for ( it.seekToFirst() ; it.isValid() ; it.next() ) {
+            for (it.seekToFirst(); it.isValid(); it.next()) {
                 count++;
             }
             return count;
@@ -782,8 +785,8 @@ public class LabelsStoreRocksDB implements LabelsStore {
 
     @Override
     public boolean isEmpty() {
-        for ( var cfh : List.of(cfhSPO, cfhS__, cfh_P_, cfh___) ) {
-            if ( !columnFamilyIsEmpty(cfh) ) {
+        for (var cfh : List.of(cfhSPO, cfhS__, cfh_P_, cfh___)) {
+            if (!columnFamilyIsEmpty(cfh)) {
                 return false;
             }
         }
@@ -800,11 +803,11 @@ public class LabelsStoreRocksDB implements LabelsStore {
     public void compact() {
         LOG.info("RocksDB label store: perform compaction");
         try {
-            for ( var cfh : allColumnFamilies() ) {
+            for (var cfh : allColumnFamilies()) {
                 var from = new byte[]{};
                 var to = new byte[16];
-                for ( int i = 0 ; i < 16 ; i++ )
-                    to[i] = (byte)-1;
+                for (int i = 0; i < 16; i++)
+                    to[i] = (byte) -1;
                 rocksDB.compactRange(cfh, from, to);
             }
         } catch (RocksDBException e) {
@@ -812,8 +815,12 @@ public class LabelsStoreRocksDB implements LabelsStore {
         }
     }
 
-    @Override
-    public void close() {
+    /**
+     * Close the underlying RocksDB instance.
+     *
+     * @param includeDictionary whether to close the dictionary labels store as well
+     */
+    public void close(boolean includeDictionary) {
         helper.closeDB();
         rocksDB = null;
         // RocksDB knows which cfh(s) it owns, and closes them as part of db.close(),
@@ -825,7 +832,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
         cfhS__ = null;
         cfh_P_ = null;
         cfh___ = null;
-        if (dictionaryLabelsStore != null) {
+        if (dictionaryLabelsStore != null && includeDictionary) {
             try {
                 dictionaryLabelsStore.close();
             } catch (Exception e) {
@@ -834,8 +841,14 @@ public class LabelsStoreRocksDB implements LabelsStore {
         }
     }
 
+    @Override
+    public void close() {
+        close(true);
+    }
+
     /**
      * Back up the underlying Rocks DB instance to given path
+     *
      * @param path location of backup
      */
     public void backup(String path) {
@@ -852,6 +865,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
 
     /**
      * Replace existing Rocks DB instance with given path.
+     *
      * @param path location of backup
      */
     public void restore(String path) {
@@ -859,7 +873,7 @@ public class LabelsStoreRocksDB implements LabelsStore {
         try (BackupEngine backupEngine = BackupEngine.open(rocksDB.getEnv(), new BackupEngineOptions(path))) {
             LOG.info("Restoring Labels Store (begin): {}", path);
             LOG.info("Restoring Labels Store (closing DB): {}", rocksDB.isClosed());
-            close();
+            close(false);
             LOG.info("Restoring Labels Store (from backup)");
             backupEngine.restoreDbFromLatestBackup(this.dbPath, path, new RestoreOptions(false));
             LOG.info("Restoring Labels Store (re-opening DB)");

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/AbstractTestLabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/AbstractTestLabelsStoreRocksDB.java
@@ -176,4 +176,15 @@ public abstract class AbstractTestLabelsStoreRocksDB {
         var z = List.of(Label.fromText("TheLabel"), Label.fromText("TheLabel"));
         assertThrows(LabelsException.class, ()->store.add(triple1, z));
     }
+
+    @ParameterizedTest(name = "{index}: Store = {1}, LabelMode = {0}")
+    @MethodSource("provideLabelAndStorageFmt")
+    public void labels_add_two_labels_for_same_triple(LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) {
+        final List<Label> labels = List.of(Label.fromText("label-1"),Label.fromText("label-2"));
+        store = createLabelsStore(labelMode, storeFmt);
+        store.add(triple1, labels);
+        List<Label> x = store.labelsForTriples(triple1);
+        assertEquals(labels, x);
+    }
+
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TS_LabelStoreRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TS_LabelStoreRocksDB.java
@@ -29,6 +29,7 @@ import org.junit.platform.suite.api.Suite;
         TestLabelsStoreRocksDBByString.class
         , TestLabelsStoreRocksDBByNodeId.class
         , TestLabelsStoreRocksDBByHash.class
+        , TestLabelsStoreRocksDBWithDictionary.class
 
 
         , TestLabelMatchRocksDBByString.class
@@ -45,6 +46,8 @@ import org.junit.platform.suite.api.Suite;
         , TestLabelMatchMem.class
 
         , TestLabelsRocksDBNormalization.class
+
+        , TestDictionaryStorageReduction.class
 })
 public class TS_LabelStoreRocksDB {
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TestDictionaryStorageReduction.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TestDictionaryStorageReduction.java
@@ -166,9 +166,9 @@ public class TestDictionaryStorageReduction {
 
                 // The main store's on-disk footprint (excluding dictionary) should also
                 // be smaller, confirming the encoding change persists through compaction.
-                assertTrue(dictionaryMetrics.totalDiskSize < regularMetrics.totalDiskSize,
+                assertTrue(dictionaryMetrics.dictionaryMainStoreDiskSize < regularMetrics.totalDiskSize,
                         String.format("Dictionary main store disk (%,d bytes) should be smaller than " +
-                                "non-dictionary store disk (%,d bytes)", dictionaryMetrics.dictionaryMainStoreDiskSize, regularMetrics.dictionaryDiskSize));
+                                "non-dictionary store disk (%,d bytes)", dictionaryMetrics.dictionaryMainStoreDiskSize, regularMetrics.totalDiskSize));
 
                 // At this scale the main store savings should outweigh the fixed
                 // dictionary overhead, yielding a net total disk reduction.

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TestDictionaryStorageReduction.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TestDictionaryStorageReduction.java
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.jena.abac.rocks;
+
+import io.telicent.jena.abac.labels.*;
+import io.telicent.smart.cache.storage.labels.DictionaryLabelsStore;
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Comparative test that measures whether dictionary-based label encoding
+ * reduces RocksDB storage compared to plain text encoding.
+ * <p>
+ * The test populates two stores with identical data — one without a dictionary,
+ * one with — compacts both, and compares storage metrics:
+ * <ul>
+ *   <li><b>approxsize</b> — RocksDB's estimate of data in the main label store
+ *       (excludes the dictionary's own RocksDB instance)</li>
+ *   <li><b>Main store disk</b> — on-disk size of the main label store directory
+ *       (excluding the dictionary subdirectory)</li>
+ *   <li><b>Total disk</b> — full on-disk size including the dictionary</li>
+ * </ul>
+ */
+public class TestDictionaryStorageReduction {
+
+    private static final Label SMALL_LABEL = Label.fromText("classification=OS");
+    private static final Label MEDIUM_LABEL = Label.fromText("classification=O&(permitted_nationalities=GBR|permitted_nationalities=NOR)&(permitted_organisations=Telicent|permitted_organisations=Telidollar)");
+    private static final Label LARGE_LABEL = Label.fromText("classification=OS&(permitted_nationalities=ALB|permitted_nationalities=AUS|permitted_nationalities=BEL|permitted_nationalities=BGR|permitted_nationalities=CAN|permitted_nationalities=HRV|permitted_nationalities=CZE|ermitted_nationalities=DNK|permitted_nationalities=EST|permitted_nationalities=FIN|permitted_nationalities=FRA|permitted_nationalities=DEU|permitted_nationalities=GRC|permitted_nationalities=HUN|permitted_nationalities=ISL|permitted_nationalities=ITA|permitted_nationalities=LVA|permitted_nationalities=LTU|permitted_nationalities=LUX|permitted_nationalities=MNE|permitted_nationalities=NLD|permitted_nationalities=NZL|permitted_nationalities=MKD|permitted_nationalities=NOR|permitted_nationalities=POL|permitted_nationalities=PRT|permitted_nationalities=ROU|permitted_nationalities=SVK|permitted_nationalities=SVN|permitted_nationalities=ESP|permitted_nationalities=SWE|permitted_nationalities=TUR|permitted_nationalities=GBR|permitted_nationalities=USA)&(permitted_organisations=ALB.ALL|permitted_organisations=AUS.ALL|permitted_organisations=BEL.ALL|permitted_organisations=BGR.ALL|permitted_organisations=CAN.ALL|permitted_organisations=HRV.ALL|permitted_organisations=CZE.ALL|permitted_organisations=DNK.ALL|permitted_organisations=EST.ALL|permitted_organisations=FIN.ALL|permitted_organisations=FRA.ALL|permitted_organisations=DEU.ALL|permitted_organisations=GRC.ALL|permitted_organisations=HUN.ALL|permitted_organisations=ISL.ALL|permitted_organisations=ITA.ALL|permitted_organisations=LVA.ALL|permitted_organisations=LTU.ALL|permitted_organisations=LUX.ALL|permitted_organisations=MNE.ALL|permitted_organisations=NLD.ALL|permitted_organisations=NZL.ALL|permitted_organisations=MKD.ALL|permitted_organisations=NOR.ALL|permitted_organisations=POL.ALL|permitted_organisations=PRT.ALL|permitted_organisations=ROU.ALL|permitted_organisations=SVK.ALL|permitted_organisations=SVN.ALL|permitted_organisations=ESP.ALL|permitted_organisations=SWE.ALL|permitted_organisations=TUR.ALL|permitted_organisations=GBR.ALL|permitted_organisations=USA.ALL|permitted_organisations=GBR.MOD)");
+    private static final List<Label> MIXED_LABELS = List.of(SMALL_LABEL, MEDIUM_LABEL, LARGE_LABEL);
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_25000_triples_and_one_small_label() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 25_000;
+        final List<Label> labels = List.of(SMALL_LABEL);
+        runTest(storeFmt, labelMode, tripleCount, labels, 5);
+    }
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_50000_triples_and_one_small_label() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 50_000;
+        final List<Label> labels = List.of(SMALL_LABEL);
+        runTest(storeFmt, labelMode, tripleCount, labels, 30);
+    }
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_20000_triples_and_one_medium_label() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 20_000;
+        final List<Label> labels = List.of(MEDIUM_LABEL);
+        runTest(storeFmt, labelMode, tripleCount, labels, 25);
+    }
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_50000_triples_and_one_medium_label() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 50_000;
+        final List<Label> labels = List.of(MEDIUM_LABEL);
+        runTest(storeFmt, labelMode, tripleCount, labels, 55);
+    }
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_1000_triples_and_one_very_large_label() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 1_000;
+        final List<Label> labels = List.of(LARGE_LABEL);
+        runTest(storeFmt, labelMode, tripleCount, labels, 10);
+    }
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_50000_triples_and_one_very_large_label() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 50_000;
+        final List<Label> labels = List.of(LARGE_LABEL);
+        runTest(storeFmt, labelMode, tripleCount, labels, 95);
+    }
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_10000_triples_and_mixed_labels() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 10_000;
+        runTest(storeFmt, labelMode, tripleCount, MIXED_LABELS, 65);
+    }
+
+    @Test
+    public void dictionaryEncoding_reduces_storage_with_20000_triples_and_mixed_labels() throws Exception {
+        final StoreFmt storeFmt = new StoreFmtByString();
+        final LabelsStoreRocksDB.LabelMode labelMode = LabelsStoreRocksDB.LabelMode.Overwrite;
+        final int tripleCount = 20_000;
+        runTest(storeFmt, labelMode, tripleCount, MIXED_LABELS, 80);
+    }
+
+    /**
+     * Populate a store with generated triples, cycling through the label set.
+     * This simulates a realistic scenario where many triples share a small
+     * number of distinct security labels.
+     */
+    private void populateStore(LabelsStore store, int count, List<Label> labels) {
+        for (int i = 0; i < count; i++) {
+            Triple triple = Triple.create(
+                    NodeFactory.createURI("http://example.org/s/" + i),
+                    NodeFactory.createURI("http://example.org/p/" + (i % 10)),
+                    NodeFactory.createURI("http://example.org/o/" + i)
+            );
+            Label label = labels.get(i % labels.size());
+            store.add(triple, label);
+        }
+    }
+
+    private void runTest(final StoreFmt storeFmt, final LabelsStoreRocksDB.LabelMode labelMode, final int tripleCount, final List<Label> labels, final int expectedReduction) throws Exception {
+        // --- Store WITHOUT dictionary ---
+        final File dbRoot = Files.createTempDirectory("database").toFile();
+        try {
+            final ResultMetrics regularMetrics = testWithoutDictionary(dbRoot, labelMode, storeFmt, tripleCount, labels);
+
+            // --- Store WITH dictionary ---
+            final File dictionaryDir = Files.createTempDirectory("dictionary").toFile();
+            try {
+                final ResultMetrics dictionaryMetrics = testWithDictionary(dbRoot, labelMode, storeFmt, tripleCount, labels);
+
+                // --- Report ---
+                printReport(regularMetrics, dictionaryMetrics, tripleCount, labels);
+
+
+                // --- Assertions ---
+                assertEquals(regularMetrics.entryCount, dictionaryMetrics.entryCount,
+                        "Both stores should have the same number of entries");
+
+                // The main store's data (approxsize) should be smaller with dictionary
+                // encoding since 8-byte integer IDs replace variable-length label text.
+                assertTrue(dictionaryMetrics.approxSize < regularMetrics.approxSize,
+                        String.format("Dictionary main store approxsize (%,d bytes) should be smaller than " +
+                                "non-dictionary approxsize (%,d bytes)", dictionaryMetrics.approxSize, regularMetrics.approxSize));
+
+                // The main store's on-disk footprint (excluding dictionary) should also
+                // be smaller, confirming the encoding change persists through compaction.
+                assertTrue(dictionaryMetrics.totalDiskSize < regularMetrics.totalDiskSize,
+                        String.format("Dictionary main store disk (%,d bytes) should be smaller than " +
+                                "non-dictionary store disk (%,d bytes)", dictionaryMetrics.dictionaryMainStoreDiskSize, regularMetrics.dictionaryDiskSize));
+
+                // At this scale the main store savings should outweigh the fixed
+                // dictionary overhead, yielding a net total disk reduction.
+                assertTrue(dictionaryMetrics.totalDiskSize < regularMetrics.totalDiskSize,
+                        String.format("Dictionary total disk (%,d bytes) should be smaller than " +
+                                "non-dictionary store disk (%,d bytes)", dictionaryMetrics.totalDiskSize, regularMetrics.totalDiskSize));
+                final double totalReduction = 100.0 * (1.0 - (double) dictionaryMetrics.totalDiskSize / regularMetrics.totalDiskSize);
+                assertTrue(totalReduction > expectedReduction);
+            } finally {
+                FileUtils.deleteDirectory(dictionaryDir);
+            }
+        } finally {
+            FileUtils.deleteDirectory(dbRoot);
+        }
+    }
+
+    private ResultMetrics testWithoutDictionary(File dbRoot, LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt, int tripleCount, List<Label> labels) throws Exception {
+        try (final LabelsStore noDictStore = Labels.createLabelsStoreRocksDB(dbRoot, labelMode, null, storeFmt)) {
+            populateStore(noDictStore, tripleCount, labels);
+            Labels.compactLabelsStoreRocksDB(noDictStore);
+            final Map<String, String> noDictProps = noDictStore.getProperties();
+            final ResultMetrics resultMetrics = new ResultMetrics(
+                    Long.parseLong(noDictProps.get("approxsize")),
+                    Long.parseLong(noDictProps.get("size")),
+                    FileUtils.sizeOfDirectory(dbRoot),
+                    null, null);
+            Labels.closeLabelsStoreRocksDB(noDictStore);
+            Labels.rocks.clear();
+            return resultMetrics;
+        }
+    }
+
+    private ResultMetrics testWithDictionary(File dbRoot, LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt, int tripleCount, List<Label> labels) throws Exception {
+        final File dictSubDir = new File(dbRoot, "dictionary");
+        dictSubDir.mkdirs();
+        try (final DictionaryLabelsStore dictLabelsStore = Labels.createDictionaryLabelsStore(dictSubDir, 1000)) {
+            try (final LabelsStore dictStore = Labels.createLabelsStoreRocksDB(dbRoot, labelMode, null, storeFmt, dictLabelsStore)) {
+                populateStore(dictStore, tripleCount, labels);
+                Labels.compactLabelsStoreRocksDB(dictStore);
+                Map<String, String> dictProps = dictStore.getProperties();
+                final long totalDiskSize = FileUtils.sizeOfDirectory(dbRoot);
+                final long dictionaryDiskSize = FileUtils.sizeOfDirectory(dictSubDir);
+                final ResultMetrics resultMetrics = new ResultMetrics(
+                        Long.parseLong(dictProps.get("approxsize")),
+                        Long.parseLong(dictProps.get("size")),
+                        totalDiskSize,
+                        dictionaryDiskSize,
+                        totalDiskSize - dictionaryDiskSize);
+                Labels.closeLabelsStoreRocksDB(dictStore);
+                Labels.rocks.clear();
+                return resultMetrics;
+            }
+        }
+    }
+
+    private void printReport(final ResultMetrics regularMetrics, final ResultMetrics dictionaryMetrics, final int tripleCount, final List<Label> labels) {
+        // --- Report ---
+        System.out.printf("%n=== Dictionary Storage Reduction Test ===%n");
+        System.out.printf("Triples inserted: %,d%n", tripleCount);
+        System.out.printf("Unique labels:    %d%n", labels.size());
+        System.out.printf("%n");
+        System.out.printf("%-30s %15s %15s%n", "", "No Dictionary", "Dictionary");
+        System.out.printf("%-30s %,15d %,15d%n", "Entry count", regularMetrics.entryCount, dictionaryMetrics.entryCount);
+        System.out.printf("%-30s %,15d %,15d%n", "Approx size (bytes)", regularMetrics.approxSize, dictionaryMetrics.approxSize);
+        System.out.printf("%-30s %,15d %,15d%n", "Main store disk (bytes)", regularMetrics.totalDiskSize, dictionaryMetrics.dictionaryMainStoreDiskSize);
+        System.out.printf("%-30s %15s %,15d%n", "Dictionary disk (bytes)", "n/a", dictionaryMetrics.dictionaryDiskSize);
+        System.out.printf("%-30s %,15d %,15d%n", "Total disk (bytes)", regularMetrics.totalDiskSize, dictionaryMetrics.totalDiskSize);
+        System.out.printf("%n");
+        if (regularMetrics.approxSize > 0) {
+            final double approxReduction = 100.0 * (1.0 - (double) dictionaryMetrics.approxSize / regularMetrics.approxSize);
+            System.out.printf("%-30s %14.1f%%%n", "Approx size reduction", approxReduction);
+        }
+        if (regularMetrics.totalDiskSize > 0) {
+            final double mainStoreReduction = 100.0 * (1.0 - (double) dictionaryMetrics.dictionaryMainStoreDiskSize / regularMetrics.totalDiskSize);
+            final double totalReduction = 100.0 * (1.0 - (double) dictionaryMetrics.totalDiskSize / regularMetrics.totalDiskSize);
+            System.out.printf("%-30s %14.1f%%%n", "Main store disk reduction", mainStoreReduction);
+            System.out.printf("%-30s %14.1f%%%n", "Total disk reduction", totalReduction);
+        }
+        System.out.printf("%n");
+        System.out.printf("%n");
+    }
+
+    private record ResultMetrics(
+            Long approxSize,
+            Long entryCount,
+            Long totalDiskSize,
+            Long dictionaryDiskSize,
+            Long dictionaryMainStoreDiskSize) {
+    }
+
+    ;
+}

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TestLabelsStoreRocksDBWithDictionary.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/TestLabelsStoreRocksDBWithDictionary.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.jena.abac.rocks;
+
+import io.telicent.jena.abac.labels.*;
+import io.telicent.smart.cache.storage.labels.DictionaryLabelsStore;
+import org.junit.jupiter.params.provider.Arguments;
+import org.rocksdb.RocksDBException;
+
+import java.io.File;
+import java.util.stream.Stream;
+
+/**
+ * Tests for LabelsStoreRocksDB with dictionary-based label encoding.
+ * Reuses the full AbstractTestLabelsStoreRocksDB test suite to verify that
+ * dictionary encoding produces the same behaviour as text encoding.
+ */
+public class TestLabelsStoreRocksDBWithDictionary extends BaseTestLabelsStoreRocksDB {
+
+    private DictionaryLabelsStore dictStore;
+
+    public static Stream<Arguments> provideLabelAndStorageFmt() {
+        return LabelAndStorageFormatProviderUtility.provideLabelAndStorageFmtByString();
+    }
+
+    @Override
+    protected LabelsStore createLabelsStoreRocksDB(File dbDir, LabelsStoreRocksDB.LabelMode labelMode, StoreFmt storeFmt) throws RocksDBException {
+        File dictDir = new File(dbDir, "dictionary");
+        dictDir.mkdirs();
+        dictStore = Labels.createDictionaryLabelsStore(dictDir, 1);
+        return Labels.createLabelsStoreRocksDB(dbDir, labelMode, null, storeFmt, dictStore);
+    }
+}


### PR DESCRIPTION
This PR modifies the `LabelsStoreRocksDB` to allow the optional injection of a `DictionaryLabelsStore` from the SC-Storage library. As this LabelsStore implementation is based on RocksDB, the `RocksDbLabelsStore` implementation of the `DictionaryLabelsStore` is used for integer encoding security labels.

One side effect of this is that two RocksDB instances are created, one for the `LabelsStore` and one for the `DictionaryLabelsStore`. The DLS maintains a mapping of integers to labels and the LS maintains a mapping of labels to triples (as before). This means that if a DLS is not in use the application will continue to work as before. Use of the DLS is configured with a boolean property `http://telicent.io/security#labelsStoreWithDictionary` in the AuthZ configuration.

As SC-Storage is currently closed source the PR will not build currently and has therefore been marked as DO NOT MERGE.