### PR TITLE
Allow ABAC filtered datasets to query quads (CORE-1187,CORE-1149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ for:
           Previously their names were based on the hash function implementation, for some hash functions which offer
           multiple hash lengths the implementation class was the same.  Thus the hashers could not be uniquely
           identified and the above store format check would incorrectly pass.
+- `ABAC.filterDataset()` now returns a `DatasetGraphFilteredView` that provides access to all named graphs in the
+  underlying `DatasetGraph` to which ABAC filtering is being applied.  Previously the resulting view would only provide
+  access to triples in the default graph.
 - Removed all remaining vestiges of deprecated pattern matching for labels 
     - **NB** Pattern based wildcard labelling was already disabled for a long time
     - Removed `LabelsStoreMemPattern`

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
     <!-- Dependency Plugins -->
     <!-- Internal dependencies -->
     <dependency.jena>6.0.0</dependency.jena>
-    <dependency.rocksdb>10.10.1</dependency.rocksdb>
     <dependency.smart-cache-storage>0.10.2</dependency.smart-cache-storage>
 
     <!-- External dependencies -->

--- a/rdf-abac-core/pom.xml
+++ b/rdf-abac-core/pom.xml
@@ -67,12 +67,6 @@
       <version>${dependency.openhft}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.rocksdb</groupId>
-      <artifactId>rocksdbjni</artifactId>
-      <version>${dependency.rocksdb}</version>
-    </dependency>
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/ABAC.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/ABAC.java
@@ -49,9 +49,8 @@ public final class ABAC {
     public final static Logger AttrLOG = LoggerFactory.getLogger("io.telicent.jena.abac.Attribute");
 
     /**
-     * Operate with old style attributes only.
-     * This applies to labels, attribute store description, and remote attribute store.
-     * No value, no quotes, any character set - no white space or =
+     * Operate with old style attributes only. This applies to labels, attribute store description, and remote attribute
+     * store. No value, no quotes, any character set - no white space or =
      */
     public static boolean LEGACY = true;
 
@@ -61,8 +60,8 @@ public final class ABAC {
     public static final int labelEvalCacheSize = 100_000;
 
     /**
-     * Per request hierarchy retrieval cache size.
-     * This could become a global cache. The answers are not request sensitive.
+     * Per request hierarchy retrieval cache size. This could become a global cache. The answers are not request
+     * sensitive.
      */
     public static final int hierarchyCacheSize = 100;
 
@@ -76,7 +75,8 @@ public final class ABAC {
     /**
      * Create a {@link DatasetGraphABAC}.
      */
-    public static DatasetGraphABAC authzDataset(DatasetGraph dsgBase, LabelsStore labels, Label datasetDefaultLabel, AttributesStore attributesStore) {
+    public static DatasetGraphABAC authzDataset(DatasetGraph dsgBase, LabelsStore labels, Label datasetDefaultLabel,
+                                                AttributesStore attributesStore) {
         return authzDataset(dsgBase, null, labels, datasetDefaultLabel, attributesStore);
     }
 
@@ -90,23 +90,23 @@ public final class ABAC {
     }
 
     /**
-     * Build an attribute-enforcing DatasetGraph. For programmatic/API use,
-     * and in unit tests.
+     * Build an attribute-enforcing DatasetGraph. For programmatic/API use, and in unit tests.
      * <p>
      * This is not used by Fuseki.
      */
-    public static DatasetGraph requestDataset(DatasetGraphABAC dsgAuthz, AttributeValueSet attributes, HierarchyGetter function) {
+    public static DatasetGraph requestDataset(DatasetGraphABAC dsgAuthz, AttributeValueSet attributes,
+                                              HierarchyGetter function) {
         CxtABAC cxt = CxtABAC.context(attributes, function, dsgAuthz.getData());
         return filterDataset(dsgAuthz, cxt);
     }
 
     /**
-     * Build an attribute-enforcing DatasetGraph. For programmatic/API use,
-     * and in unit tests.
+     * Build an attribute-enforcing DatasetGraph. For programmatic/API use, and in unit tests.
      * <p>
      * This is not used by Fuseki.
      */
-    public static DatasetGraph requestDataset(DatasetGraphABAC dsgAuthz, AttributeValueSet attributes, AttributesStore attrStore) {
+    public static DatasetGraph requestDataset(DatasetGraphABAC dsgAuthz, AttributeValueSet attributes,
+                                              AttributesStore attrStore) {
         CxtABAC cxt = CxtABAC.context(attributes, attrStore, dsgAuthz.getData());
         return filterDataset(dsgAuthz, cxt);
     }
@@ -123,18 +123,23 @@ public final class ABAC {
     /**
      * Create an attribute-filtered dataset for a context.
      * <p>
-     * "No label store" (null) is not the same as an empty label store
-     * ({@link LabelsStoreZero}). "No store" mean the label filter isn't even
-     * incorporated into decisions whereas an empty store may have a default.
-     * <p>The DatasetGraph is the data storage dataset.
+     * "No label store" (null) is not the same as an empty label store ({@link LabelsStoreZero}). "No store" mean the
+     * label filter isn't even incorporated into decisions whereas an empty store may have a default.
+     * </p>
+     *
+     * @param dsgBase      The data storage dataset.
+     * @param labels       Label store (if any)
+     * @param defaultLabel Default label to apply if no specific label applies to a quad
+     * @param cxt          ABAC Evaluation context
      */
-    public static DatasetGraph filterDataset(DatasetGraph dsgBase, LabelsStore labels, Label defaultLabel, CxtABAC cxt) {
+    public static DatasetGraph filterDataset(DatasetGraph dsgBase, LabelsStore labels, Label defaultLabel,
+                                             CxtABAC cxt) {
         QuadFilter filter = null;
         if (labels != null) {
             LabelsGetter getter = labels::labelForQuad;
             filter = Labels.securityFilterByLabel(getter, defaultLabel, cxt);
         }
-        return new DatasetGraphFilteredView(dsgBase, filter, Set.of());
+        return new DatasetGraphFilteredView(dsgBase, filter, new AllNamedGraphs(dsgBase));
     }
 
     /**

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/AllNamedGraphs.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/AllNamedGraphs.java
@@ -4,6 +4,7 @@ import org.apache.jena.atlas.lib.NotImplemented;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
 
 import java.util.*;
 
@@ -41,18 +42,20 @@ class AllNamedGraphs implements Collection<Node> {
     private void ensureNamedGraphs() {
         if (this.namedGraphs == null) {
             this.namedGraphs = new HashSet<>();
-            Iterator<Node> it = this.dsg.listGraphNodes();
-            if (it != null) {
-                while (it.hasNext()) {
-                    Node g = it.next();
-                    // Ignore null/default graph
-                    // DatasetGraphFilteredView will try to "fix" us if we report these as named graphs
-                    if (g == null || Quad.isDefaultGraph(g)) {
-                        continue;
+            Txn.executeRead(this.dsg, () -> {
+                Iterator<Node> it = this.dsg.listGraphNodes();
+                if (it != null) {
+                    while (it.hasNext()) {
+                        Node g = it.next();
+                        // Ignore null/default graph
+                        // DatasetGraphFilteredView will try to "fix" us if we report these as named graphs
+                        if (g == null || Quad.isDefaultGraph(g)) {
+                            continue;
+                        }
+                        this.namedGraphs.add(g);
                     }
-                    this.namedGraphs.add(g);
                 }
-            }
+            });
         }
     }
 

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/AllNamedGraphs.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/AllNamedGraphs.java
@@ -1,0 +1,130 @@
+package io.telicent.jena.abac;
+
+import org.apache.jena.atlas.lib.NotImplemented;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+
+import java.util.*;
+
+/**
+ * A wrapper to allow exposing all named graphs in the underlying dataset by default to a
+ * {@link org.apache.jena.sparql.core.DatasetGraphFilteredView}.  Note that this implements only the methods of the
+ * interface required for {@link org.apache.jena.sparql.core.DatasetGraphFilteredView} to function, any other method
+ * will throw {@link NotImplemented}.  Hence, this class is private to restrict its usage only to RDF-ABAC internal
+ * needs.
+ * <p>
+ * Internally this computes and caches the set of visible named graphs once, and only once, for its lifetime.  This
+ * ensures that even if the computation is expensive we only incur its cost once.
+ * </p>
+ */
+class AllNamedGraphs implements Collection<Node> {
+
+    private final DatasetGraph dsg;
+    private Set<Node> namedGraphs = null;
+
+    /**
+     * Creates a new wrapper
+     *
+     * @param dsg Underlying dataset whose named graphs we wish to make visible
+     */
+    public AllNamedGraphs(DatasetGraph dsg) {
+        this.dsg = Objects.requireNonNull(dsg, "Dataset Graph cannot be null");
+    }
+
+    /**
+     * Obtain and cache the list of named graphs for the lifetime of this request once, and only once, since obtaining
+     * this from the underlying storage may be an expensive operation.  For TDB2 at least this should be an efficient
+     * prefix scan over one of the indexes with G as the first portion of the key but for large databases this still can
+     * take some time.
+     */
+    private void ensureNamedGraphs() {
+        if (this.namedGraphs == null) {
+            this.namedGraphs = new HashSet<>();
+            Iterator<Node> it = this.dsg.listGraphNodes();
+            if (it != null) {
+                while (it.hasNext()) {
+                    Node g = it.next();
+                    // Ignore null/default graph
+                    // DatasetGraphFilteredView will try to "fix" us if we report these as named graphs
+                    if (g == null || Quad.isDefaultGraph(g)) {
+                        continue;
+                    }
+                    this.namedGraphs.add(g);
+                }
+            }
+        }
+    }
+
+    @Override
+    public int size() {
+        ensureNamedGraphs();
+        return this.namedGraphs.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        ensureNamedGraphs();
+        return this.namedGraphs.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        ensureNamedGraphs();
+        return this.namedGraphs.contains(o);
+    }
+
+    @Override
+    public Iterator<Node> iterator() {
+        ensureNamedGraphs();
+        return this.namedGraphs.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        ensureNamedGraphs();
+        return this.namedGraphs.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        ensureNamedGraphs();
+        return this.namedGraphs.toArray(a);
+    }
+
+    @Override
+    public boolean add(Node node) {
+        throw new NotImplemented();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new NotImplemented();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        ensureNamedGraphs();
+        return this.namedGraphs.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends Node> c) {
+        throw new NotImplemented();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new NotImplemented();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new NotImplemented();
+    }
+
+    @Override
+    public void clear() {
+        throw new NotImplemented();
+    }
+}

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
@@ -46,6 +46,7 @@ import org.junit.platform.suite.api.Suite;
     , TestLabelsStoreMem.class
     , TestTransactionalMemory.class
     , TestAllNamedGraphs.class
+    , TestAllNamedGraphsTdb2.class
     , TestAE.class
     , TestABAC.class
     , TestCtxABAC.class

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
@@ -43,9 +43,9 @@ import org.junit.platform.suite.api.Suite;
     , TestLabelsMem.class
     , TestLabelsMemNoPatterns.class
     , TestAssemblerABAC.class
-
     , TestLabelsStoreMem.class
     , TestTransactionalMemory.class
+    , TestAllNamedGraphs.class
     , TestAE.class
     , TestABAC.class
     , TestCtxABAC.class

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphs.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphs.java
@@ -1,11 +1,11 @@
 package io.telicent.jena.abac;
 
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.sparql.core.DatasetGraphWrapper;
-import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.core.*;
+import org.apache.jena.system.Txn;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -13,10 +13,34 @@ import java.time.Duration;
 import java.util.Iterator;
 
 public class TestAllNamedGraphs {
-
     public static final org.apache.jena.graph.Node SUBJECT = NodeFactory.createURI("https://s");
     public static final org.apache.jena.graph.Node PREDICATE = NodeFactory.createURI("https://p");
     public static final org.apache.jena.graph.Node OBJECT = NodeFactory.createLiteralString("object");
+
+    public static void addNamedGraphs(DatasetGraph dsg, int numGraphs) {
+        Txn.executeWrite(dsg, () -> {
+            for (int i = 1; i <= numGraphs; i++) {
+                dsg.add(graphName(i), SUBJECT, PREDICATE, OBJECT);
+            }
+        });
+    }
+
+    public static void addNamedGraphsUniqueTriples(DatasetGraph dsg, int numGraphs) {
+        Txn.executeWrite(dsg, () -> {
+            for (int i = 1; i <= numGraphs; i++) {
+                dsg.add(graphName(i), SUBJECT, PREDICATE,
+                        NodeFactory.createLiteralDT(Integer.toString(i), XSDDatatype.XSDinteger));
+            }
+        });
+    }
+
+    public static void verifyNamedGraphPresent(AllNamedGraphs ang, Node graph) {
+        Assertions.assertTrue(ang.contains(graph));
+    }
+
+    public static Node graphName(int i) {
+        return NodeFactory.createURI("https://graphs/" + i);
+    }
 
     @Test
     public void givenEmptyDataset_whenWrappingWithAllNamedGraphs_thenEmptyReported() {
@@ -44,20 +68,6 @@ public class TestAllNamedGraphs {
         Assertions.assertTrue(ang.isEmpty());
         Assertions.assertEquals(0, ang.size());
         Assertions.assertFalse(ang.contains(Quad.defaultGraphIRI));
-    }
-
-    private void addNamedGraphs(DatasetGraph dsg, int numGraphs) {
-        for (int i = 1; i <= numGraphs; i++) {
-            dsg.add(graphName(i), SUBJECT, PREDICATE, OBJECT);
-        }
-    }
-
-    private void verifyNamedGraphPresent(AllNamedGraphs ang, Node graph) {
-        Assertions.assertTrue(ang.contains(graph));
-    }
-
-    private static Node graphName(int i) {
-        return NodeFactory.createURI("https://graphs/" + i);
     }
 
     @Test
@@ -110,5 +120,48 @@ public class TestAllNamedGraphs {
             }
             return super.listGraphNodes();
         }
+    }
+
+    @Test
+    public void givenFilteredDatasetViewWithAllNamedGraphsHavingSameTriple_whenAccessingUnionGraph_thenSingleTripleReturned() {
+        // Given
+        DatasetGraph dsgBase = DatasetGraphFactory.create();
+        addNamedGraphs(dsgBase, 100);
+        DatasetGraphFilteredView dsgFiltered = new DatasetGraphFilteredView(dsgBase, null, new AllNamedGraphs(dsgBase));
+
+        // When
+        Graph union = dsgFiltered.getUnionGraph();
+
+        // Then
+        Assertions.assertEquals(1, union.size());
+    }
+
+    @Test
+    public void givenFilteredDatasetViewWithAllNamedGraphsHavingDifferentTriples_whenAccessingUnionGraph_thenAllTriplesReturned() {
+        // Given
+        DatasetGraph dsgBase = DatasetGraphFactory.create();
+        addNamedGraphsUniqueTriples(dsgBase, 100);
+        DatasetGraphFilteredView dsgFiltered = new DatasetGraphFilteredView(dsgBase, null, new AllNamedGraphs(dsgBase));
+
+        // When
+        Graph union = dsgFiltered.getUnionGraph();
+
+        // Then
+        Assertions.assertEquals(100, union.size());
+    }
+
+    @Test
+    public void givenFilteredDatasetViewWithAllNamedGraphsAndNegativeQuadFilter_whenAccessingUnionGraph_thenNoTriplesReturned() {
+        // Given
+        DatasetGraph dsgBase = DatasetGraphFactory.create();
+        addNamedGraphsUniqueTriples(dsgBase, 50);
+        DatasetGraphFilteredView dsgFiltered =
+                new DatasetGraphFilteredView(dsgBase, q -> false, new AllNamedGraphs(dsgBase));
+
+        // When
+        Graph union = dsgFiltered.getUnionGraph();
+
+        // Then
+        Assertions.assertEquals(0, union.size());
     }
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphs.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphs.java
@@ -1,0 +1,114 @@
+package io.telicent.jena.abac;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.DatasetGraphWrapper;
+import org.apache.jena.sparql.core.Quad;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Iterator;
+
+public class TestAllNamedGraphs {
+
+    public static final org.apache.jena.graph.Node SUBJECT = NodeFactory.createURI("https://s");
+    public static final org.apache.jena.graph.Node PREDICATE = NodeFactory.createURI("https://p");
+    public static final org.apache.jena.graph.Node OBJECT = NodeFactory.createLiteralString("object");
+
+    @Test
+    public void givenEmptyDataset_whenWrappingWithAllNamedGraphs_thenEmptyReported() {
+        // Given
+        DatasetGraph dsg = DatasetGraphFactory.empty();
+
+        // When
+        AllNamedGraphs ang = new AllNamedGraphs(dsg);
+
+        // Then
+        Assertions.assertTrue(ang.isEmpty());
+        Assertions.assertEquals(0, ang.size());
+    }
+
+    @Test
+    public void givenDatasetWithDefaultGraphOnly_whenWrappingWithAllNamedGraphs_thenEmptyReported() {
+        // Given
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        dsg.add(Quad.defaultGraphIRI, SUBJECT, PREDICATE, OBJECT);
+
+        // When
+        AllNamedGraphs ang = new AllNamedGraphs(dsg);
+
+        // Then
+        Assertions.assertTrue(ang.isEmpty());
+        Assertions.assertEquals(0, ang.size());
+        Assertions.assertFalse(ang.contains(Quad.defaultGraphIRI));
+    }
+
+    private void addNamedGraphs(DatasetGraph dsg, int numGraphs) {
+        for (int i = 1; i <= numGraphs; i++) {
+            dsg.add(graphName(i), SUBJECT, PREDICATE, OBJECT);
+        }
+    }
+
+    private void verifyNamedGraphPresent(AllNamedGraphs ang, Node graph) {
+        Assertions.assertTrue(ang.contains(graph));
+    }
+
+    private static Node graphName(int i) {
+        return NodeFactory.createURI("https://graphs/" + i);
+    }
+
+    @Test
+    public void givenDatasetWithNamedGraphs_whenWrappingWithAllNamedGraphs_thenNamedGraphsListed() {
+        // Given
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        addNamedGraphs(dsg, 5);
+
+        // When
+        AllNamedGraphs ang = new AllNamedGraphs(dsg);
+
+        // Then
+        Assertions.assertFalse(ang.isEmpty());
+        Assertions.assertEquals(5L, ang.size());
+        for (int i = 1; i <= 5; i++) {
+            verifyNamedGraphPresent(ang, graphName(i));
+        }
+    }
+
+    @Test
+    public void givenDatasetWithSlowNamedGraphComputation_whenWrappingWithAllNamedGraphs_thenComputationCostIncurredOnce() {
+        // Given
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        addNamedGraphs(dsg, 10);
+
+        // When
+        AllNamedGraphs ang = new AllNamedGraphs(new DatasetSlowNamedGraphComputation(dsg));
+
+        // Then
+        long start = System.currentTimeMillis();
+        Assertions.assertFalse(ang.isEmpty());
+        Assertions.assertTrue(System.currentTimeMillis() - start > 3_000);
+        start = System.currentTimeMillis();
+        Assertions.assertEquals(10, ang.size());
+        Assertions.assertTrue(System.currentTimeMillis() - start < 3_000);
+    }
+
+    private static final class DatasetSlowNamedGraphComputation extends DatasetGraphWrapper {
+
+        public DatasetSlowNamedGraphComputation(DatasetGraph dsg) {
+            super(dsg);
+        }
+
+        @Override
+        public Iterator<Node> listGraphNodes() {
+            try {
+                Thread.sleep(Duration.ofSeconds(3));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return super.listGraphNodes();
+        }
+    }
+}

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphsTdb2.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphsTdb2.java
@@ -60,10 +60,10 @@ public class TestAllNamedGraphsTdb2 {
             long start = System.currentTimeMillis();
             Assertions.assertFalse(ang.isEmpty());
             long elapsed = System.currentTimeMillis() - start;
-            System.out.println("Initial Computation: " + elapsed);
+            //System.out.println("Initial Computation: " + elapsed);
             start = System.currentTimeMillis();
             Assertions.assertEquals(numGraphs, ang.size());
-            System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
+            //System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
             Assertions.assertTrue(System.currentTimeMillis() - start < elapsed);
         } finally {
             dsg.close();
@@ -91,10 +91,10 @@ public class TestAllNamedGraphsTdb2 {
             long start = System.currentTimeMillis();
             Assertions.assertTrue(ang.isEmpty());
             long elapsed = System.currentTimeMillis() - start;
-            System.out.println("Initial Computation: " + elapsed);
+            //System.out.println("Initial Computation: " + elapsed);
             start = System.currentTimeMillis();
             Assertions.assertEquals(0, ang.size());
-            System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
+            //System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
             Assertions.assertTrue(System.currentTimeMillis() - start <= elapsed);
         } finally {
             dsg.close();
@@ -125,7 +125,7 @@ public class TestAllNamedGraphsTdb2 {
                     Assertions.assertTrue(qexec.ask());
                     long elapsed = System.currentTimeMillis() - start;
                     Assertions.assertTrue(elapsed < 1_000);
-                    System.out.println("Query took: " + elapsed);
+                    //System.out.println("Query took: " + elapsed);
                 }
             });
         } finally {
@@ -158,10 +158,10 @@ public class TestAllNamedGraphsTdb2 {
             start = System.currentTimeMillis();
             Assertions.assertFalse(ang.isEmpty());
             long elapsed = System.currentTimeMillis() - start;
-            System.out.println("Initial Computation: " + elapsed);
+            //System.out.println("Initial Computation: " + elapsed);
             start = System.currentTimeMillis();
             Assertions.assertEquals(10_000, ang.size());
-            System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
+            //System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
             Assertions.assertTrue(System.currentTimeMillis() - start < elapsed);
         } finally {
             dsg.close();

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphsTdb2.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphsTdb2.java
@@ -1,0 +1,170 @@
+package io.telicent.jena.abac;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.*;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.QueryExecDatasetBuilder;
+import org.apache.jena.system.Txn;
+import org.apache.jena.tdb2.TDB2Factory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.stream.Stream;
+
+import static io.telicent.jena.abac.TestAllNamedGraphs.*;
+
+/**
+ * Tests that verify {@link AllNamedGraphs} behaves correctly with a TDB2 backed database and doesn't incur undue
+ * performance penalties
+ */
+public class TestAllNamedGraphsTdb2 {
+
+    private File dbDir;
+
+    @BeforeEach
+    public void setupTdb() throws IOException {
+        this.dbDir = Files.createTempDirectory("tdb2").toFile();
+    }
+
+    @AfterEach
+    public void teardownTdb() throws IOException {
+        FileUtils.deleteDirectory(this.dbDir);
+    }
+
+    private static Stream<Arguments> graphSizes() {
+        return Stream.of(Arguments.of(100), Arguments.of(10_000), Arguments.of(100_000));
+    }
+
+    @ParameterizedTest
+    @MethodSource("graphSizes")
+    public void givenTdb2Dataset_whenWrappingWithAllNamedGraphs_thenComputationCostIncurredOnce(int numGraphs) {
+        // Given
+        DatasetGraph dsg = TDB2Factory.connectDataset(dbDir.getAbsolutePath()).asDatasetGraph();
+        try {
+            addNamedGraphs(dsg, numGraphs);
+
+            // When
+            AllNamedGraphs ang = new AllNamedGraphs(dsg);
+
+            // Then
+            long start = System.currentTimeMillis();
+            Assertions.assertFalse(ang.isEmpty());
+            long elapsed = System.currentTimeMillis() - start;
+            System.out.println("Initial Computation: " + elapsed);
+            start = System.currentTimeMillis();
+            Assertions.assertEquals(numGraphs, ang.size());
+            System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
+            Assertions.assertTrue(System.currentTimeMillis() - start < elapsed);
+        } finally {
+            dsg.close();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("graphSizes")
+    public void givenTdb2DatasetWithNoNamedGraphs_whenWrappingWithAllNamedGraphs_thenComputationCostIncurredOnce(
+            int numTriples) {
+        // Given
+        DatasetGraph dsg = TDB2Factory.connectDataset(dbDir.getAbsolutePath()).asDatasetGraph();
+        try {
+            Txn.executeWrite(dsg, () -> {
+                for (int i = 1; i <= numTriples; i++) {
+                    dsg.add(Quad.defaultGraphIRI, SUBJECT, PREDICATE,
+                            NodeFactory.createLiteralString(Integer.toString(i)));
+                }
+            });
+
+            // When
+            AllNamedGraphs ang = new AllNamedGraphs(dsg);
+
+            // Then
+            long start = System.currentTimeMillis();
+            Assertions.assertTrue(ang.isEmpty());
+            long elapsed = System.currentTimeMillis() - start;
+            System.out.println("Initial Computation: " + elapsed);
+            start = System.currentTimeMillis();
+            Assertions.assertEquals(0, ang.size());
+            System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
+            Assertions.assertTrue(System.currentTimeMillis() - start <= elapsed);
+        } finally {
+            dsg.close();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("graphSizes")
+    public void givenTdb2DatasetWithNamedGraphs_whenWrappingWithAllNamedGraphs_thenQueryingOnlyDefaultGraphIncursNoPerformancePenalty(
+            int numGraphs) {
+        // Given
+        DatasetGraph dsg = TDB2Factory.connectDataset(dbDir.getAbsolutePath()).asDatasetGraph();
+        try {
+            addNamedGraphs(dsg, numGraphs);
+            Txn.executeWrite(dsg, () -> dsg.add(Quad.defaultGraphIRI, SUBJECT, PREDICATE, OBJECT));
+
+            // When
+            AllNamedGraphs ang = new AllNamedGraphs(dsg);
+            DatasetGraphFilteredView dsgFiltered = new DatasetGraphFilteredView(dsg, null, ang);
+
+            // Then
+            Txn.executeRead(dsgFiltered, () -> {
+                try (QueryExec qexec = QueryExecDatasetBuilder.create()
+                                                              .dataset(dsgFiltered)
+                                                              .query("ASK WHERE { ?s ?p ?o }")
+                                                              .build()) {
+                    long start = System.currentTimeMillis();
+                    Assertions.assertTrue(qexec.ask());
+                    long elapsed = System.currentTimeMillis() - start;
+                    Assertions.assertTrue(elapsed < 1_000);
+                    System.out.println("Query took: " + elapsed);
+                }
+            });
+        } finally {
+            dsg.close();
+        }
+    }
+
+    @Test
+    public void givenVeryLargeTdb2Dataset_whenWrappingWithAllNamedGraphs_thenComputationCostIncurredOnce() {
+        // Given
+        DatasetGraph dsg = TDB2Factory.connectDataset(dbDir.getAbsolutePath()).asDatasetGraph();
+        try {
+            // Generate 10_000_000 triples
+            long start = System.currentTimeMillis();
+            System.out.println("Generating very large test dataset...");
+            Txn.executeWrite(dsg, () -> {
+              for (int g = 1; g <= 10_000; g++) {
+                  Node graph = NodeFactory.createURI("https://graphs/" + g);
+                  for (int t = 1; t <= 1_000; t++) {
+                      dsg.add(graph, SUBJECT, PREDICATE, NodeFactory.createLiteralString("object " + t));
+                  }
+              }
+            });
+            System.out.format("Generating very large test dataset complete in %,d milliseconds\n", System.currentTimeMillis() - start);
+
+            // When
+            AllNamedGraphs ang = new AllNamedGraphs(dsg);
+
+            // Then
+            start = System.currentTimeMillis();
+            Assertions.assertFalse(ang.isEmpty());
+            long elapsed = System.currentTimeMillis() - start;
+            System.out.println("Initial Computation: " + elapsed);
+            start = System.currentTimeMillis();
+            Assertions.assertEquals(10_000, ang.size());
+            System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
+            Assertions.assertTrue(System.currentTimeMillis() - start < elapsed);
+        } finally {
+            dsg.close();
+        }
+    }
+}


### PR DESCRIPTION
In the course of testing out the 3.x changes with SC-Graph discovered that the way `ABAC.filterDataset()` generates a `DatasetGraphFilteredView` meant that it would only ever expose data in the default graph and prevented queries from accessing data in named graphs.  Since the 3.x changes mean we can label quads properly this restriction is now relaxed and the resulting `DatasetGraphFilteredView` will now expose all named graphs from the underlying dataset for query (subject of course to the requesting user satisfying the labels on those quads)