### PR TITLE
Fixing flaky test

### DIFF
--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphsTdb2.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestAllNamedGraphsTdb2.java
@@ -64,7 +64,7 @@ public class TestAllNamedGraphsTdb2 {
             start = System.currentTimeMillis();
             Assertions.assertEquals(numGraphs, ang.size());
             //System.out.println("Subsequent Computation: " + (System.currentTimeMillis() - start));
-            Assertions.assertTrue(System.currentTimeMillis() - start < elapsed);
+            Assertions.assertTrue(System.currentTimeMillis() - start <= elapsed);
         } finally {
             dsg.close();
         }


### PR DESCRIPTION
Attempting to fix flaky test where `start` and `elapsed` time can both be 0ms when JVM is warmed up.