### PR TITLE
CORE-1199: allow datasets to be filtered by named graphs

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/ABAC.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/ABAC.java
@@ -20,6 +20,7 @@ import io.telicent.jena.abac.assembler.SecuredDatasetAssembler;
 import io.telicent.jena.abac.core.*;
 import io.telicent.jena.abac.labels.*;
 import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParser;
 import org.apache.jena.shacl.ShaclValidator;
@@ -33,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * Programmatic API to the Attribute-Based Access Control functionality.
@@ -90,6 +91,18 @@ public final class ABAC {
     }
 
     /**
+     * Create a {@link DatasetGraphABAC} with a fixed set of visible named graphs.
+     *
+     * @param visibleNamedGraphs named graphs visible for query; {@code null} means all graphs are visible
+     */
+    public static DatasetGraphABAC authzDataset(DatasetGraph dsgBase, String accessAttributes,
+                                                LabelsStore labels, Label datasetDefaultLabel,
+                                                AttributesStore attributesStore,
+                                                Collection<Node> visibleNamedGraphs) {
+        return new DatasetGraphABAC(dsgBase, accessAttributes, labels, datasetDefaultLabel, attributesStore, visibleNamedGraphs);
+    }
+
+    /**
      * Build an attribute-enforcing DatasetGraph. For programmatic/API use, and in unit tests.
      * <p>
      * This is not used by Fuseki.
@@ -113,11 +126,16 @@ public final class ABAC {
 
     /**
      * Create an attribute-filtered dataset for a context.
+     * Uses the dataset's {@link DatasetGraphABAC#getVisibleNamedGraphs() visible named graphs} if configured,
+     * otherwise all named graphs in the dataset are visible.
      *
      * @see #requestDataset
      */
     public static DatasetGraph filterDataset(DatasetGraphABAC dsgAuthz, CxtABAC cxt) {
-        return filterDataset(dsgAuthz.getData(), dsgAuthz.labelsStore(), dsgAuthz.getDefaultLabel(), cxt);
+        final Collection<Node> visibleGraphs = dsgAuthz.getVisibleNamedGraphs() != null
+                ? dsgAuthz.getVisibleNamedGraphs()
+                : new AllNamedGraphs(dsgAuthz.getData());
+        return filterDataset(dsgAuthz.getData(), dsgAuthz.labelsStore(), dsgAuthz.getDefaultLabel(), cxt, visibleGraphs);
     }
 
     /**
@@ -134,12 +152,30 @@ public final class ABAC {
      */
     public static DatasetGraph filterDataset(DatasetGraph dsgBase, LabelsStore labels, Label defaultLabel,
                                              CxtABAC cxt) {
-        QuadFilter filter = null;
+        return filterDataset(dsgBase, labels, defaultLabel, cxt, new AllNamedGraphs(dsgBase));
+    }
+
+    /**
+     * Create an attribute-filtered dataset for a context, restricted to a specific set of named graphs.
+     *
+     * @param dsgBase       The data storage dataset.
+     * @param labels        Label store (if any)
+     * @param defaultLabel  Default label to apply if no specific label applies to a quad
+     * @param cxt           ABAC Evaluation context
+     * @param visibleGraphs The named graphs exposed to the query
+     */
+    public static DatasetGraph filterDataset(DatasetGraph dsgBase, LabelsStore labels, Label defaultLabel,
+                                             CxtABAC cxt, Collection<Node> visibleGraphs) {
         if (labels != null) {
-            LabelsGetter getter = labels::labelForQuad;
-            filter = Labels.securityFilterByLabel(getter, defaultLabel, cxt);
+            final QuadFilter filter = getQuadFilter(labels, defaultLabel, cxt);
+            return new DatasetGraphFilteredView(dsgBase, filter, visibleGraphs);
         }
-        return new DatasetGraphFilteredView(dsgBase, filter, new AllNamedGraphs(dsgBase));
+        return new DatasetGraphFilteredView(dsgBase, null, visibleGraphs);
+    }
+
+    private static QuadFilter getQuadFilter(LabelsStore labels, Label defaultLabel, CxtABAC cxt) {
+        final LabelsGetter getter = labels::labelForQuad;
+        return Labels.securityFilterByLabel(getter, defaultLabel, cxt);
     }
 
     /**

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/assembler/Secured.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/assembler/Secured.java
@@ -19,6 +19,10 @@ package io.telicent.jena.abac.assembler;
 import static io.telicent.jena.abac.core.VocabAuthzDataset.*;
 import static org.apache.jena.sparql.util.graph.GraphUtils.getStringValue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -31,6 +35,8 @@ import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.jena.abac.labels.LabelsStoreMem;
 import org.apache.jena.assembler.exceptions.AssemblerException;
 import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
@@ -75,8 +81,9 @@ public class Secured {
         Label tripleDefaultLabel = AttributeStoreBuildLib.getTripleDefaultLabel(attributesStoreRoot);
         AttributesStore attributesStore = AttributeStoreBuildLib.attributesStore(attributesStoreRoot);
 
+        Set<Node> visibleNamedGraphs = loadVisibleNamedGraphs(assemblerRoot);
         DatasetGraphABAC dsgAuthz =
-                ABAC.authzDataset(base, accessAttributes, labels, tripleDefaultLabel, attributesStore);
+                ABAC.authzDataset(base, accessAttributes, labels, tripleDefaultLabel, attributesStore, visibleNamedGraphs);
         return dsgAuthz;
     }
 
@@ -222,6 +229,36 @@ public class Secured {
             }
         }
         return false;
+    }
+
+    /**
+     * Read {@code authz:visibleGraphsFile} from the assembler root and load the listed graph URIs.
+     * Returns {@code null} when the property is absent (meaning all graphs are visible).
+     * <p>
+     * File format: one graph URI per line; blank lines and lines starting with {@code #} are ignored.
+     * </p>
+     */
+    private static Set<Node> loadVisibleNamedGraphs(Resource assemblerRoot) {
+        final String filePath = getStringValue(assemblerRoot, pVisibleGraphsFile);
+        if (filePath == null) {
+            return null;
+        }
+        try {
+            final Set<Node> graphs = new LinkedHashSet<>();
+            for (String line : Files.readAllLines(Path.of(filePath))) {
+                final String trimmed = line.strip();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                    // ignore blank lines and comments
+                    continue;
+                }
+                graphs.add(NodeFactory.createURI(trimmed));
+            }
+            FmtLog.info(BUILD_LOG, "Loaded %d visible named graphs from: %s", graphs.size(), filePath);
+            return graphs;
+        } catch (IOException e) {
+            throw new AssemblerException(assemblerRoot,
+                    "Failed to read visible graphs file '" + filePath + "': " + e.getMessage());
+        }
     }
 
     /**

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/DatasetGraphABAC.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/DatasetGraphABAC.java
@@ -21,11 +21,14 @@ import io.telicent.jena.abac.AE;
 import io.telicent.jena.abac.attributes.AttributeExpr;
 import io.telicent.jena.abac.labels.Label;
 import io.telicent.jena.abac.labels.LabelsStore;
+import org.apache.jena.graph.Node;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphWrapper;
 import org.apache.jena.sparql.core.Transactional;
+
+import java.util.Collection;
 
 public class DatasetGraphABAC extends DatasetGraphWrapper {
     // Attribute expression used to determine whether access is allowed.
@@ -38,6 +41,8 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
     // Can be null for system-wide policy (which is deny).
     private final Label defaultLabel;
     private final AttributesStore attributesStore;
+    // Optional fixed set of named graphs visible for query. Null means all named graphs are visible.
+    private final Collection<Node> visibleNamedGraphs;
 
     /**
      * API: use {@link ABAC#authzDataset}
@@ -45,12 +50,24 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
     public DatasetGraphABAC(DatasetGraph base, String accessAttributes,
                             LabelsStore labelsStore, Label datasetDefaultLabel,
                             AttributesStore attributesStore) {
+        this(base, accessAttributes, labelsStore, datasetDefaultLabel, attributesStore, null);
+    }
+
+    /**
+     * API: use {@link ABAC#authzDataset}
+     *
+     * @param visibleNamedGraphs the named graphs visible for query, or {@code null} to allow all named graphs
+     */
+    public DatasetGraphABAC(DatasetGraph base, String accessAttributes,
+                            LabelsStore labelsStore, Label datasetDefaultLabel,
+                            AttributesStore attributesStore, Collection<Node> visibleNamedGraphs) {
         super(base);
         this.accessAttributesStr = accessAttributes;
         this.accessAttributesExpr = AE.parseExpr(accessAttributesStr);
         this.labelsStore = labelsStore;
         this.defaultLabel = datasetDefaultLabel;
         this.attributesStore = attributesStore;
+        this.visibleNamedGraphs = visibleNamedGraphs;
     }
 
     /**
@@ -74,6 +91,13 @@ public class DatasetGraphABAC extends DatasetGraphWrapper {
 
     public LabelsStore labelsStore() {
         return labelsStore;
+    }
+
+    /**
+     * Returns the fixed set of named graphs visible for query, or {@code null} if all named graphs are visible.
+     */
+    public Collection<Node> getVisibleNamedGraphs() {
+        return visibleNamedGraphs;
     }
 
     @Override

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/VocabAuthzDataset.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/core/VocabAuthzDataset.java
@@ -130,6 +130,13 @@ public class VocabAuthzDataset {
      */
     public static Property pTripleDefaultLabels = ResourceFactory.createProperty(NS+"tripleDefaultLabels");
 
+    /**
+     * Optional path to a file listing the named graph URIs that are visible for query.
+     * Each line in the file is treated as a graph URI; blank lines and lines starting
+     * with {@code #} are ignored. When absent, all named graphs in the dataset are visible.
+     */
+    public static Property pVisibleGraphsFile = ResourceFactory.createProperty(NS+"visibleGraphsFile");
+
     /** @deprecated Use {@link #pTripleDefaultLabels} */
     @Deprecated
     public static Property pTripleDefaultAttributes = ResourceFactory.createProperty(NS+"tripleDefaultAttributes");

--- a/rdf-abac-core/src/test/files/dataset/abac-assembler-visible-graphs-bad.ttl
+++ b/rdf-abac-core/src/test/files/dataset/abac-assembler-visible-graphs-bad.ttl
@@ -1,0 +1,15 @@
+## ABAC Dataset assembler with a nonexistent authz:visibleGraphsFile - expects AssemblerException.
+
+PREFIX :        <#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX authz:   <http://telicent.io/security#>
+
+<#datasetAuth> rdf:type authz:DatasetAuthz ;
+    authz:labels <file:labels-1.ttl> ;
+    authz:dataset :basedata ;
+    authz:attributes <file:attribute-store.ttl> ;
+    authz:visibleGraphsFile "src/test/files/dataset/nonexistent-visible-graphs.txt" ;
+    .
+
+:basedata rdf:type ja:MemoryDataset .

--- a/rdf-abac-core/src/test/files/dataset/abac-assembler-visible-graphs.ttl
+++ b/rdf-abac-core/src/test/files/dataset/abac-assembler-visible-graphs.ttl
@@ -1,0 +1,15 @@
+## ABAC Dataset assembler with authz:visibleGraphsFile configured.
+
+PREFIX :        <#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX authz:   <http://telicent.io/security#>
+
+<#datasetAuth> rdf:type authz:DatasetAuthz ;
+    authz:labels <file:labels-1.ttl> ;
+    authz:dataset :basedata ;
+    authz:attributes <file:attribute-store.ttl> ;
+    authz:visibleGraphsFile "src/test/files/dataset/visible-graphs.txt" ;
+    .
+
+:basedata rdf:type ja:MemoryDataset .

--- a/rdf-abac-core/src/test/files/dataset/visible-graphs.txt
+++ b/rdf-abac-core/src/test/files/dataset/visible-graphs.txt
@@ -1,0 +1,5 @@
+# Visible named graphs for testing.
+# Blank lines and lines starting with '#' are ignored.
+
+http://telicent.io/graph#1
+http://telicent.io/graph#2

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TS_ABAC_Core.java
@@ -47,6 +47,7 @@ import org.junit.platform.suite.api.Suite;
     , TestTransactionalMemory.class
     , TestAllNamedGraphs.class
     , TestAllNamedGraphsTdb2.class
+    , TestVisibleNamedGraphsFile.class
     , TestAE.class
     , TestABAC.class
     , TestCtxABAC.class

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestVisibleNamedGraphsFile.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/TestVisibleNamedGraphsFile.java
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.jena.abac;
+
+import io.telicent.jena.abac.assembler.Secured;
+import io.telicent.jena.abac.core.AttributesStore;
+import io.telicent.jena.abac.core.CxtABAC;
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.jena.abac.labels.Labels;
+import org.apache.jena.atlas.logging.LogCtl;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sys.JenaSystem;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static io.telicent.jena.abac.TestAllNamedGraphs.addNamedGraphs;
+import static io.telicent.jena.abac.TestAllNamedGraphs.graphName;
+import static io.telicent.jena.abac.TestAssemblerABAC.assemble;
+import static io.telicent.jena.abac.TestAssemblerABAC.assembleBad;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the {@code authz:visibleGraphsFile} feature, which loads the set of
+ * visible named graphs from a plain-text file.
+ */
+public class TestVisibleNamedGraphsFile {
+
+    static {
+        JenaSystem.init();
+    }
+
+    private static final String TEST_DIR = "src/test/files/dataset/";
+
+    @BeforeAll
+    public static void beforeAll() {
+        Labels.rocks.clear();
+        LogCtl.set(Secured.BUILD_LOG, "error");
+    }
+
+    @AfterEach
+    public void afterEach() {
+        Labels.rocks.clear();
+    }
+
+    // ---- Assembler configuration tests
+
+    @Test
+    public void givenAssemblerWithNoVisibleGraphsFile_whenAssembled_thenVisibleNamedGraphsIsNull() {
+        // Given / When
+        final DatasetGraphABAC dsg = assemble(TEST_DIR + "abac-assembler-1.ttl");
+
+        // Then (null means all named graphs are visible)
+        assertNull(dsg.getVisibleNamedGraphs());
+        dsg.close();
+    }
+
+    @Test
+    public void givenAssemblerWithValidVisibleGraphsFile_whenAssembled_thenListedGraphsAreLoaded() {
+        // Given / When
+        final DatasetGraphABAC dsg = assemble(TEST_DIR + "abac-assembler-visible-graphs.ttl");
+
+        //Then
+        final Collection<Node> allowed = dsg.getVisibleNamedGraphs();
+        assertNotNull(allowed);
+        assertEquals(2, allowed.size());
+        assertTrue(allowed.contains(NodeFactory.createURI("http://telicent.io/graph#1")));
+        assertTrue(allowed.contains(NodeFactory.createURI("http://telicent.io/graph#2")));
+        dsg.close();
+    }
+
+    @Test
+    public void givenAssemblerWithMissingVisibleGraphsFile_thenAssemblerExceptionIsThrown() {
+        assembleBad(TEST_DIR + "abac-assembler-visible-graphs-bad.ttl");
+    }
+
+    // ---- Filter behaviour tests ----
+
+    @Test
+    public void givenDatasetAbacWithNullVisibleGraphs_whenFiltered_thenAllNamedGraphsAreVisible() {
+        // Given
+        final DatasetGraph dsgBase = DatasetGraphFactory.create();
+        addNamedGraphs(dsgBase, 3);
+        final DatasetGraphABAC dsgAuthz = ABAC.authzDataset(dsgBase, null, null, null,
+                Mockito.mock(AttributesStore.class), null);
+
+        // When
+        final DatasetGraph filtered = ABAC.filterDataset(dsgAuthz, Mockito.mock(CxtABAC.class));
+
+        // Then
+        final List<Node> visible = listGraphNodes(filtered);
+        assertEquals(3, visible.size());
+        for (int i = 1; i <= 3; i++) {
+            assertTrue(visible.contains(graphName(i)), "Expected graph " + i + " to be visible");
+        }
+    }
+
+    @Test
+    public void givenDatasetAbacWithRestrictedVisibleGraphs_whenFiltered_thenOnlyVisibleNamedGraphsAreVisible() {
+        // Given
+        final DatasetGraph dsgBase = DatasetGraphFactory.create();
+        addNamedGraphs(dsgBase, 3);
+        final Set<Node> visibleGraphs = Set.of(graphName(1), graphName(2));
+        final DatasetGraphABAC dsgAuthz = ABAC.authzDataset(dsgBase, null, null, null,
+                Mockito.mock(AttributesStore.class), visibleGraphs);
+
+        // When
+        final DatasetGraph filtered = ABAC.filterDataset(dsgAuthz, Mockito.mock(CxtABAC.class));
+
+        // Then
+        final List<Node> visible = listGraphNodes(filtered);
+        assertEquals(2, visible.size());
+        assertTrue(visible.contains(graphName(1)));
+        assertTrue(visible.contains(graphName(2)));
+        assertFalse(visible.contains(graphName(3)));
+    }
+
+    @Test
+    public void givenDatasetAbacWithEmptyVisibleGraphs_whenFiltered_thenNoNamedGraphsAreVisible() {
+        // Given
+        final DatasetGraph dsgBase = DatasetGraphFactory.create();
+        addNamedGraphs(dsgBase, 3);
+        final DatasetGraphABAC dsgAuthz = ABAC.authzDataset(dsgBase, null, null, null,
+                Mockito.mock(AttributesStore.class), Set.of());
+
+        // When
+        final DatasetGraph filtered = ABAC.filterDataset(dsgAuthz, Mockito.mock(CxtABAC.class));
+
+        // Then (an empty set of visible graphs means the visible graphs file is available but no graphs are specified)
+        assertTrue(listGraphNodes(filtered).isEmpty());
+    }
+
+    private static List<Node> listGraphNodes(DatasetGraph dsg) {
+        final List<Node> nodes = new ArrayList<>();
+        dsg.listGraphNodes().forEachRemaining(nodes::add);
+        return nodes;
+    }
+}

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/ABAC_SHACL_Validation.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/ABAC_SHACL_Validation.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.jena.abac.fuseki;
+
+import static java.lang.String.format;
+import static org.apache.jena.fuseki.servlets.GraphTarget.determineTarget;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.apache.jena.atlas.web.MediaType;
+import org.apache.jena.fuseki.DEF;
+import org.apache.jena.fuseki.servlets.*;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.riot.web.HttpNames;
+import org.apache.jena.shacl.ShaclValidator;
+import org.apache.jena.shacl.ValidationReport;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.web.HttpSC;
+
+/**
+ * SHACL validation service with ABAC filtering applied to the data graph.
+ * <p>
+ * The shapes graph is supplied by the caller in the request body (POST), so it is
+ * not filtered. The data graph is the ABAC-filtered view of the dataset for the
+ * requesting user, meaning the user only receives validation errors for data they
+ * are authorised to see.
+ * </p>
+ */
+public class ABAC_SHACL_Validation extends SHACL_Validation implements ABAC_Processor {
+
+    private final Function<HttpAction, String> getUser;
+
+    public ABAC_SHACL_Validation(Function<HttpAction, String> getUser) {
+        this.getUser = Objects.requireNonNull(getUser, "getUser is null");
+    }
+
+    @Override
+    protected void doPost(HttpAction action) {
+        MediaType mediaType = ActionLib.contentNegotation(action, DEF.rdfOffer, DEF.acceptTurtle);
+        Lang lang = RDFLanguages.contentTypeToLang(mediaType.getContentTypeStr());
+        if (lang == null)
+            lang = RDFLanguages.TTL;
+
+        String targetNodeStr = action.getRequestParameter(HttpNames.paramTarget);
+
+        action.beginRead();
+        try {
+            // getActiveDSG() is only valid after beginRead(); apply ABAC filtering here.
+            DatasetGraph filteredDsg = ABAC_Request.decideDataset(action, action.getActiveDSG(), getUser);
+
+            GraphTarget graphTarget = determineTarget(filteredDsg, action);
+            if (!graphTarget.exists())
+                ServletOps.errorNotFound("No data graph: " + graphTarget.label());
+            Graph data = graphTarget.graph();
+            Graph shapesGraph = ActionLib.readFromRequest(action, Lang.TTL);
+
+            Node targetNode = null;
+            if (targetNodeStr != null) {
+                String x = data.getPrefixMapping().expandPrefix(targetNodeStr);
+                targetNode = NodeFactory.createURI(x);
+            }
+
+            ValidationReport report = (targetNode == null)
+                    ? ShaclValidator.get().validate(shapesGraph, data)
+                    : ShaclValidator.get().validate(shapesGraph, data, targetNode);
+
+            if (report.conforms())
+                action.log.info(format("[%d] shacl: conforms", action.id));
+            else
+                action.log.info(format("[%d] shacl: %d validation error(s)", action.id, report.getEntries().size()));
+
+            action.setResponseStatus(HttpSC.OK_200);
+            ActionLib.graphResponse(action, report.getGraph(), lang);
+        } finally {
+            action.endRead();
+        }
+    }
+}

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/FMod_ABAC.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/FMod_ABAC.java
@@ -115,10 +115,13 @@ public class FMod_ABAC implements FusekiModule {
         ActionProcessor procGSPR = new ABAC_GSP_R(getUser);
         ActionProcessor procUpload = new ABAC_ChangeDispatch();
 
+        ActionProcessor procShacl = new ABAC_SHACL_Validation(getUser);
+
         // Replace standard processors with ABAC ones.
         replaceOperation(dap, Operation.Query,  procQuery);
         replaceOperation(dap, Operation.GSP_R,  procGSPR);
         replaceOperation(dap, Operation.Upload, procUpload);
+        replaceOperation(dap, Operation.Shacl,  procShacl);
 
         // Warn about the use of these operations.
         warnOperation(dap, Operation.Update);

--- a/rdf-abac-fuseki/src/test/files/server/config-server-shacl.ttl
+++ b/rdf-abac-fuseki/src/test/files/server/config-server-shacl.ttl
@@ -1,0 +1,24 @@
+## Server configuration for SHACL validation tests.
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+PREFIX authz:   <http://telicent.io/security#>
+
+:service1 rdf:type fuseki:Service ;
+    fuseki:name "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:shacl ; fuseki:name "shacl" ] ;
+    fuseki:endpoint [ fuseki:operation authz:upload  ; fuseki:name "upload" ] ;
+    fuseki:dataset :dataset ;
+    .
+
+:dataset rdf:type authz:DatasetAuthz ;
+    authz:attributes <file:attribute-store.ttl> ;
+    authz:tripleDefaultLabels "*" ;
+    authz:dataset :datasetBase ;
+    .
+
+:datasetBase rdf:type ja:MemoryDataset .

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TS_ABAC_Fuseki.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TS_ABAC_Fuseki.java
@@ -25,6 +25,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({
     TestServerABAC.class
     , TestServer_FMod_ABAC.class
+    , TestShaclABAC.class
     , TestAttributesStoreRemote.class
     , TestLabelledDataLoader.class
     , UserInfoEnrichmentFilterTest.class

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestShaclABAC.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestShaclABAC.java
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.jena.abac.fuseki;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiModule;
+import org.apache.jena.fuseki.main.sys.FusekiModules;
+import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for ABAC-filtered SHACL validation endpoint.
+ * <p>
+ * Verifies that when a user POSTs shapes to the SHACL endpoint, the data graph
+ * validated is the ABAC-filtered view for that user — so the user only receives
+ * validation errors for data they are authorised to see.
+ * </p>
+ * <p>
+ * Test data: `:s :mustBeInt "not-an-integer"` is labeled {@code manager};
+ * `:s :mustBeInt 100` is labeled {@code engineer}.  The shape asserts that all
+ * {@code :mustBeInt} values must be {@code xsd:integer}.
+ * </p>
+ * <ul>
+ *   <li>u1 (manager) — sees the non-integer value → validation reports a violation</li>
+ *   <li>u2 (engineer) — sees only the valid integer value → validation conforms</li>
+ * </ul>
+ */
+public class TestShaclABAC {
+
+    static {
+        FusekiLogging.setLogging();
+    }
+
+    private static final String DIR = "src/test/files/server/";
+
+    // Data loaded before each test: two :mustBeInt values with different labels.
+    private static final String SHACL_TEST_DATA = """
+            Content-type: application/trig
+
+            PREFIX : <http://example/>
+            PREFIX authz: <http://telicent.io/security#>
+
+            :s :mustBeInt "not-an-integer" .
+            :s :mustBeInt 100 .
+
+            GRAPH authz:labels {
+                [ authz:pattern ':s :mustBeInt "not-an-integer"' ; authz:label "manager" ] .
+                [ authz:pattern ':s :mustBeInt 100' ; authz:label "engineer" ] .
+            }
+            """;
+
+    // Shape: all :mustBeInt values must be xsd:integer.
+    private static final String INTEGER_SHAPE = """
+            PREFIX sh:  <http://www.w3.org/ns/shacl#>
+            PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+            PREFIX :    <http://example/>
+
+            :MustBeIntegerShape
+                a sh:NodeShape ;
+                sh:targetSubjectsOf :mustBeInt ;
+                sh:property [
+                    sh:path     :mustBeInt ;
+                    sh:datatype xsd:integer ;
+                ] .
+            """;
+
+    private static final String SH_CONFORMS = "http://www.w3.org/ns/shacl#conforms";
+
+    private FusekiServer server;
+    private String shaclURL;
+    private String uploadURL;
+
+    @BeforeAll
+    public static void beforeAll() {
+        FusekiLogging.setLogging();
+    }
+
+    @BeforeEach
+    public void setup() {
+        FusekiModule fmod = new FMod_ABAC();
+        FusekiModules mods = FusekiModules.create(List.of(fmod));
+        server = FusekiServer.create()
+                .port(0)
+                .fusekiModules(mods)
+                .parseConfigFile(FileOps.concatPaths(DIR, "config-server-shacl.ttl"))
+                .build()
+                .start();
+
+        String base = "http://localhost:" + server.getPort() + "/ds";
+        shaclURL  = base + "/shacl?default";
+        uploadURL = base + "/upload";
+
+        PlayLib.sendStringHTTP(uploadURL, SHACL_TEST_DATA);
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (server != null)
+            server.stop();
+    }
+
+    @Test
+    public void givenNoAuthorizationHeader_whenShaclValidate_thenBadRequest() throws IOException, InterruptedException {
+        HttpResponse<String> response = shaclPost(shaclURL, null, INTEGER_SHAPE);
+        assertEquals(400, response.statusCode());
+    }
+
+    @Test
+    public void givenManagerUser_whenShaclValidate_thenViolationReportedForInvisibleData()
+            throws IOException, InterruptedException {
+        // u1 has the manager attribute and can see :s :mustBeInt "not-an-integer".
+        // "not-an-integer" is not an xsd:integer, so the shape must report a violation.
+        HttpResponse<String> response = shaclPost(shaclURL, "u1", INTEGER_SHAPE);
+        assertEquals(200, response.statusCode());
+        assertFalse(shaclConforms(response.body()), "Expected SHACL violation for u1 (manager)");
+    }
+
+    @Test
+    public void givenEngineerUser_whenShaclValidate_thenNoViolationForDataOutsideTheirView()
+            throws IOException, InterruptedException {
+        // u2 has the engineer attribute and can only see :s :mustBeInt 100.
+        // 100 is a valid xsd:integer, so the shape must conform — even though the
+        // manager-labeled "not-an-integer" value exists in the underlying dataset.
+        HttpResponse<String> response = shaclPost(shaclURL, "u2", INTEGER_SHAPE);
+        assertEquals(200, response.statusCode());
+        assertTrue(shaclConforms(response.body()), "Expected SHACL to conform for u2 (engineer)");
+    }
+
+    // ---- helpers ----
+
+    private static HttpResponse<String> shaclPost(String url, String user, String shapesTtl)
+            throws IOException, InterruptedException {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "text/turtle")
+                .POST(HttpRequest.BodyPublishers.ofString(shapesTtl));
+        if (user != null)
+            builder.header("Authorization", "Bearer user:" + user);
+        return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static boolean shaclConforms(String responseTtl) {
+        Model report = ModelFactory.createDefaultModel();
+        RDFParser.fromString(responseTtl, Lang.TTL).parse(report);
+        Property conforms = report.createProperty(SH_CONFORMS);
+        return report.listStatements(null, conforms, (org.apache.jena.rdf.model.RDFNode) null)
+                .nextStatement()
+                .getObject()
+                .asLiteral()
+                .getBoolean();
+    }
+}


### PR DESCRIPTION
This PR addresses spike [CORE-1199](https://telicent.atlassian.net/browse/CORE-1199) by adding the ability to filter the named graphs available to query by listing them in a text file which is specified by a new property `authz:visibleGraphsFile` in the Fuseki assembler.

As this PR is a spike and subject to change it should not be merged at this time. Documentation will also need to be added if the implementation proceeds in it's present form. 

[CORE-1199]: https://telicent.atlassian.net/browse/CORE-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ