### PR TITLE
Backup/restore/compact support for 3.x Rocks store (CORE-1149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log :: RDF ABAC
 
+## 3.1.0
+
+- RocksDB improvements:
+    - Added backup/restore and compaction support to `DictionaryLabelsStoreRocksDB`
+- Build improvements:
+    - Apache Commons Codec upgraded to 2.21.0
+    - Apache Commons IO upgraded to 2.22.0
+    - Smart Cache Storage upgraded to 0.11.1
+
 ## 3.0.0
 
 This is a major version with signficant **BREAKING CHANGES** that will require consumers to adapt their existing code

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.telicent.jena</groupId>
   <artifactId>rdf-abac</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>Telicent ABAC</name>
@@ -66,7 +66,7 @@
     <automatic.module.name>io.telicent.rdfabac</automatic.module.name>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> 
-    <project.build.outputTimestamp>2026-04-22T13:28:45Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-04-28T12:16:40Z</project.build.outputTimestamp>
     <java.version>21</java.version>
 
     <!-- Maven Plugins -->
@@ -91,7 +91,7 @@
     <!-- Dependency Plugins -->
     <!-- Internal dependencies -->
     <dependency.jena>6.0.0</dependency.jena>
-    <dependency.smart-cache-storage>0.10.3</dependency.smart-cache-storage>
+    <dependency.smart-cache-storage>0.11.1</dependency.smart-cache-storage>
 
     <!-- External dependencies -->
     <dependency.assert>3.27.7</dependency.assert>

--- a/rdf-abac-benchmark/pom.xml
+++ b/rdf-abac-benchmark/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.telicent.jena</groupId>
         <artifactId>rdf-abac</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/rdf-abac-core/pom.xml
+++ b/rdf-abac-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>rdf-abac</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
@@ -4,6 +4,9 @@ import io.telicent.jena.abac.labels.*;
 import io.telicent.jena.abac.labels.hashing.HasherUtil;
 import io.telicent.jena.abac.labels.store.rocksdb.legacy.LegacyLabelsStoreRocksDB;
 import io.telicent.jena.abac.labels.store.rocksdb.legacy.RocksDBHelper;
+import io.telicent.smart.cache.storage.RestoreConfig;
+import io.telicent.smart.cache.storage.RestoreException;
+import io.telicent.smart.cache.storage.RestoreStatus;
 import io.telicent.smart.cache.storage.labels.rocksdb.RocksDbLabelsStore;
 import io.telicent.smart.cache.storage.rocksdb.KeyValue;
 import io.telicent.smart.cache.storage.rocksdb.TransactionContext;
@@ -47,6 +50,7 @@ import java.util.function.BiConsumer;
  * retrieved post migration.
  * </p>
  */
+@SuppressWarnings("deprecation")
 public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements LabelsStore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DictionaryLabelStoreRocksDB.class);
@@ -315,7 +319,18 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
 
     @Override
     public Map<String, String> getProperties() {
-        return Map.of();
+        return Map.of("size", Long.toString(this.keyCount()));
+    }
+
+    @Override
+    public RestoreStatus restore(RestoreConfig config) throws RestoreException {
+        RestoreStatus status = super.restore(config);
+        // Upon successful restore clear the labels cache otherwise we could return outdated labels for quads whose
+        // labels have previously been cached
+        if (status.isSuccess()) {
+            this.labelCache.clear();
+        }
+        return status;
     }
 
     /**

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/BulkDirectory.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/BulkDirectory.java
@@ -19,8 +19,10 @@ import io.telicent.jena.abac.SysABAC;
 import io.telicent.jena.abac.labels.*;
 import io.telicent.jena.abac.labels.store.rocksdb.legacy.LegacyLabelsStoreRocksDB;
 import io.telicent.platform.play.PlayFiles;
+import io.telicent.smart.cache.storage.*;
 import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sys.JenaSystem;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -50,8 +52,12 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Abstract base for tests which load large data sets into label stores
  */
-@SuppressWarnings({ "deprecation"})
+@SuppressWarnings({ "deprecation" })
 public abstract class BulkDirectory {
+
+    static {
+        JenaSystem.init();
+    }
 
     protected static Logger LOG = LoggerFactory.getLogger(BulkDirectory.class);
 
@@ -178,7 +184,7 @@ public abstract class BulkDirectory {
             playFiles(AFTER_DIR, labelsStore);
 
             var label = LabelsLoadingConsumer.labelsForTriple(labelsStore,
-                                                               "<https://starwars.com#grid_R7> <http://ies.data.gov.uk/ontology/ies4#inLocation> <https://starwars.com#AGalaxyFarFarAway> .");
+                                                              "<https://starwars.com#grid_R7> <http://ies.data.gov.uk/ontology/ies4#inLocation> <https://starwars.com#AGalaxyFarFarAway> .");
 
             //Check that a member of the AFTER_DIR has ONLY the latest label (overwrite mode)
             assertNotNull(label);
@@ -202,37 +208,59 @@ public abstract class BulkDirectory {
                     "<https://starwars.com#grid_R7> <http://ies.data.gov.uk/ontology/ies4#inLocation> <https://starwars.com#AGalaxyFarFarAway> .";
             Label labelBefore = Label.fromText("security=unknowndefault");
 
-            if (labelsStore instanceof LegacyLabelsStoreRocksDB rocksDB) {
+            if (supportsBackupRestore(labelsStore)) {
                 Path tempDir = Files.createTempDirectory("backup");
-                LabelsLoadingConsumer.addLabelsForTriple(labelsStore, tripleString, labelBefore);
-                var label = LabelsLoadingConsumer.labelsForTriple(labelsStore, tripleString);
-
-                assertNotNull(label);
-                assertEquals(labelBefore, label);
+                loadDataWithLabel(labelsStore, tripleString, labelBefore);
 
                 // Back-up
-                rocksDB.backup(tempDir.toString());
+                backup(labelsStore, tempDir);
 
                 // Make some changes
-                LabelsLoadingConsumer.addLabelsForTriple(labelsStore, tripleString,
-                                                         Label.fromText("security=somethingelse"));
-                label = LabelsLoadingConsumer.labelsForTriple(labelsStore, tripleString);
-
-
-                assertNotNull(label);
+                Label label = loadDataWithLabel(labelsStore, tripleString, Label.fromText("security=somethingelse"));
                 assertNotEquals(labelBefore, label);
 
                 // Restore
-                rocksDB.restore(tempDir.toString());
+                restore(labelsStore, tempDir);
 
                 label = LabelsLoadingConsumer.labelsForTriple(labelsStore, tripleString);
                 assertNotNull(label);
-                //assertEquals(labelBefore, labels.get(0));
-
-                rocksDB.close();
-
+                assertEquals(labelBefore, label);
             }
         }
+    }
+
+    protected boolean supportsBackupRestore(LabelsStore labelsStore) {
+        return labelsStore instanceof LegacyLabelsStoreRocksDB || labelsStore instanceof BackupRestoreCapable;
+    }
+
+    private static void restore(LabelsStore labelsStore, Path tempDir) {
+        if (labelsStore instanceof LegacyLabelsStoreRocksDB rocksDB) {
+            rocksDB.restore(tempDir.toString());
+        } else if (labelsStore instanceof BackupRestoreCapable restoreCapable) {
+            RestoreStatus status = restoreCapable.restore(
+                    RestoreConfig.builder().backupLocation(tempDir.toFile().getAbsolutePath()).build());
+            assertTrue(status.isSuccess());
+        }
+    }
+
+    private static void backup(LabelsStore labelsStore, Path tempDir) {
+        if (labelsStore instanceof LegacyLabelsStoreRocksDB rocksDB) {
+            rocksDB.backup(tempDir.toString());
+        } else if (labelsStore instanceof BackupRestoreCapable backupCapable) {
+            BackupStatus status = backupCapable.backup(
+                    BackupConfig.builder().backupLocation(tempDir.toFile().getAbsolutePath()).build());
+            assertTrue(status.isSuccess());
+        }
+    }
+
+    private static Label loadDataWithLabel(LabelsStore labelsStore, String tripleString, Label labelToApply) {
+        LabelsLoadingConsumer.addLabelsForTriple(labelsStore, tripleString, labelToApply);
+        var label = LabelsLoadingConsumer.labelsForTriple(labelsStore, tripleString);
+
+        assertNotNull(label);
+        assertEquals(labelToApply, label);
+
+        return label;
     }
 
     @ParameterizedTest(name = "{index}: Store = {0},")

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/BulkDirectoryModernRocksDBTestsByHash.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/bulk/BulkDirectoryModernRocksDBTestsByHash.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.telicent.jena.abac.bulk;
+
+import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.jena.abac.labels.StoreFmt;
+import io.telicent.jena.abac.labels.store.rocksdb.modern.DictionaryLabelStoreRocksDB;
+import io.telicent.jena.abac.rocks.StorageFormatProviderUtility;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.Arguments;
+import org.rocksdb.RocksDBException;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+/**
+ * Run {@link BulkDirectory} tests using the hash-based RocksDB label store,
+ * using a setup extension which creates the right kind of store.
+ * Due to the additional needs of a Hasher implementation we disable the tests and re-implement them
+ * to allow us to set up the relevant hasher as acquired from the HasherUtil map.
+ */
+@ExtendWith(RocksDBSetupExtension.class)
+public class BulkDirectoryModernRocksDBTestsByHash extends AbstractBulkDirectoryRocksDB {
+
+    @Override
+    LabelsStore createLabelsStore(StoreFmt storeFmt) throws RocksDBException {
+        try {
+            return new DictionaryLabelStoreRocksDB(dbDir, storeFmt);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Stream<Arguments> provideStorageFormat() {
+        return StorageFormatProviderUtility.provideStorageFormatsByHash();
+    }
+}

--- a/rdf-abac-coverage-report/pom.xml
+++ b/rdf-abac-coverage-report/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.telicent.jena</groupId>
         <artifactId>rdf-abac</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/rdf-abac-eval/pom.xml
+++ b/rdf-abac-eval/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>rdf-abac</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>rdf-abac-core</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -52,19 +52,19 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>rdf-abac-core</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>rdf-abac-fuseki</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>rdf-abac-fuseki</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/rdf-abac-fuseki-server/pom.xml
+++ b/rdf-abac-fuseki-server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.telicent.jena</groupId>
         <artifactId>rdf-abac</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/rdf-abac-fuseki/pom.xml
+++ b/rdf-abac-fuseki/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>rdf-abac</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>rdf-abac-core</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>rdf-abac-core</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This commit upgrades to Smart Cache Storage 0.11.0 which adds backup/restore and compaction support to the new
DictionaryLabelsStoreRocksDB.