### PR TITLE
CORE-605: enable ABAC for SHACL validation

### DIFF
--- a/docs/abac-fuseki-server.md
+++ b/docs/abac-fuseki-server.md
@@ -139,3 +139,23 @@ curl -X POST --location 'http://localhost:3030/unsecuredDataset/query' \
 --header 'Content-Type: application/sparql-query' \
 --data 'SELECT (COUNT(*) AS ?count)  WHERE { ?s ?p ?o }' 
 ```
+
+### Validation (Secured)
+#### Upload
+```bash
+curl --location 'http://localhost:3030/securedDataset/upload' \
+--header 'Security-Label: *' \
+--header 'Content-Type: application/trig' \
+--data-binary '@../rdf-abac-fuseki/src/test/files/server/shacl-data.trig'
+```
+*Note:* We are indicating that the default label be `*` such that any data without an explicit label defined is
+accesible
+#### Validate
+```bash
+curl --location 'http://localhost:3030/securedDataset/shacl?graph=default' \
+--header 'Content-Type: text/turtle' \
+--header 'Authorization: Bearer  dXNlcjpKYW5l' \
+--data-binary '@../rdf-abac-fuseki/src/test/files/server/shacl-shape.ttl'
+```
+Only data visible to the user will be validated. This means that the validation report will show conformity even if
+there is invalid data which the user cannot see due to its security labelling.

--- a/docs/abac-fuseki.md
+++ b/docs/abac-fuseki.md
@@ -20,12 +20,13 @@ This section describes the ABAC authorization configuration. This can be combine
 
 ### Service Configuration
 
-There are two classes of operations:
+There are three classes of operations:
 
 1. loading data.
 2. accessing data.
+3. validating data.
 
-ABAC security applies to access operations, SPARQL queries and SPARQL Graph Store Protocol read operations (HTTP GET).
+ABAC security applies to access operations, SPARQL queries, SPARQL Graph Store Protocol read operations (HTTP GET) and SHACL validation.
 
 Loading data and data labels is performed by an ABAC-specific service.
 The endpoint must be protected by ensuring only trusted remote services can access
@@ -52,8 +53,8 @@ is the data loading operation.
 
 > *NOTE:* SPARQL Update is not currently supported.
 
-The Fuseki module will also check for and rewire the standard operations using the Fuseki namespace
-that is using `fuseki:query` instead of `authz:query` if the dataset supports ABAC. This form must
+The Fuseki module will also check for and rewire the standard operations using the Fuseki namespace. For example,
+using `fuseki:query` instead of `authz:query` if the dataset supports ABAC. This form must
 be used if defining multiple operations on a single endpoint and using Fuseki ability
 to route based on introspection of the request.
 
@@ -63,6 +64,7 @@ to route based on introspection of the request.
 
     fuseki:endpoint [ fuseki:operation fuseki:query ] ;
     fuseki:endpoint [ fuseki:operation fuseki:gsp-r ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:shacl ] ;
     fuseki:endpoint [ fuseki:operation authz:upload ; fuseki:name "upload" ] ;
 ```
 

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/ABAC_SHACL_Validation.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/ABAC_SHACL_Validation.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.jena.abac.fuseki;
+
+import org.apache.jena.atlas.web.MediaType;
+import org.apache.jena.fuseki.DEF;
+import org.apache.jena.fuseki.servlets.*;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.riot.web.HttpNames;
+import org.apache.jena.shacl.ShaclValidator;
+import org.apache.jena.shacl.ValidationReport;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.web.HttpSC;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import static org.apache.jena.fuseki.servlets.GraphTarget.determineTarget;
+
+/**
+ * SHACL validation service with ABAC filtering applied to the data graph.
+ */
+public class ABAC_SHACL_Validation extends SHACL_Validation implements ABAC_Processor {
+
+    private final Function<HttpAction, String> getUser;
+
+    public ABAC_SHACL_Validation(Function<HttpAction, String> getUser) {
+        this.getUser = Objects.requireNonNull(getUser, "getUser is null");
+    }
+
+    @Override
+    protected void doPost(HttpAction action) {
+        final MediaType mediaType = ActionLib.contentNegotation(action, DEF.rdfOffer, DEF.acceptTurtle);
+        final Lang lang = Objects.requireNonNullElse(
+                RDFLanguages.contentTypeToLang(mediaType.getContentTypeStr()), RDFLanguages.TTL);
+        final String targetNodeStr = action.getRequestParameter(HttpNames.paramTarget);
+        action.beginRead();
+        try {
+            final DatasetGraph abacFilteredDsg = ABAC_Request.decideDataset(action, action.getActiveDSG(), getUser);
+            final GraphTarget graphTarget = determineTarget(abacFilteredDsg, action);
+            if (!graphTarget.exists()) {
+                ServletOps.errorNotFound("No data graph: " + graphTarget.label());
+            }
+            final Graph data = graphTarget.graph();
+            final Graph shapesGraph = ActionLib.readFromRequest(action, Lang.TTL);
+            final Node targetNode = getTargetNode(targetNodeStr, data);
+            final ValidationReport report = (targetNode == null)
+                    ? ShaclValidator.get().validate(shapesGraph, data)
+                    : ShaclValidator.get().validate(shapesGraph, data, targetNode);
+
+            if (report.conforms())
+                action.log.info("[{}] shacl: conforms", action.id);
+            else
+                action.log.info("[{}] shacl: {} validation error(s)", action.id, report.getEntries().size());
+
+            action.setResponseStatus(HttpSC.OK_200);
+            ActionLib.graphResponse(action, report.getGraph(), lang);
+        } finally {
+            action.endRead();
+        }
+    }
+
+    private Node getTargetNode(String targetNodeStr, Graph data) {
+        if (targetNodeStr != null) {
+            final String x = data.getPrefixMapping().expandPrefix(targetNodeStr);
+            return NodeFactory.createURI(x);
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/FMod_ABAC.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/FMod_ABAC.java
@@ -115,10 +115,13 @@ public class FMod_ABAC implements FusekiModule {
         ActionProcessor procGSPR = new ABAC_GSP_R(getUser);
         ActionProcessor procUpload = new ABAC_ChangeDispatch();
 
+        ActionProcessor procShacl = new ABAC_SHACL_Validation(getUser);
+
         // Replace standard processors with ABAC ones.
         replaceOperation(dap, Operation.Query,  procQuery);
         replaceOperation(dap, Operation.GSP_R,  procGSPR);
         replaceOperation(dap, Operation.Upload, procUpload);
+        replaceOperation(dap, Operation.Shacl,  procShacl);
 
         // Warn about the use of these operations.
         warnOperation(dap, Operation.Update);

--- a/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/CmdFusekiABAC.java
+++ b/rdf-abac-fuseki/src/main/java/io/telicent/jena/abac/fuseki/server/CmdFusekiABAC.java
@@ -93,8 +93,7 @@ public class CmdFusekiABAC {
         Filter filter = new AuthBearerFilter(Authn::getUserFromToken64, BearerMode.REQUIRED);
 
         FusekiServer.Builder builder =
-            FusekiMain.builder(args)
-                .fusekiModules(modules)
+            FusekiMain.builder(modules, args)
                 // .addFilter("/*", filter)
                 ;
         return builder;

--- a/rdf-abac-fuseki/src/test/files/server/config-server-shacl.ttl
+++ b/rdf-abac-fuseki/src/test/files/server/config-server-shacl.ttl
@@ -1,0 +1,24 @@
+## Server configuration for SHACL validation tests.
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+PREFIX authz:   <http://telicent.io/security#>
+
+:service1 rdf:type fuseki:Service ;
+    fuseki:name "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:shacl ; fuseki:name "shacl" ] ;
+    fuseki:endpoint [ fuseki:operation authz:upload  ; fuseki:name "upload" ] ;
+    fuseki:dataset :dataset ;
+    .
+
+:dataset rdf:type authz:DatasetAuthz ;
+    authz:attributes <file:attribute-store.ttl> ;
+    authz:tripleDefaultLabels "*" ;
+    authz:dataset :datasetBase ;
+    .
+
+:datasetBase rdf:type ja:MemoryDataset .

--- a/rdf-abac-fuseki/src/test/files/server/shacl-data.trig
+++ b/rdf-abac-fuseki/src/test/files/server/shacl-data.trig
@@ -1,0 +1,18 @@
+PREFIX authz: <http://telicent.io/security#>
+PREFIX ex:    <http://example.org/ns#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+
+ex:Alice
+    a              foaf:Person ;
+    foaf:givenName "Alice" ;
+    foaf:knows     ex:Bob .
+
+ex:Bob
+    a              foaf:Person ;
+    foaf:givenName "Bob" ;
+    foaf:knows     ex:Alice .
+
+GRAPH authz:labels {
+    [ authz:pattern '<http://example.org/ns#Alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/ns#Bob>' ; authz:label "manager" ] .
+    [ authz:pattern '<http://example.org/ns#Bob> <http://xmlns.com/foaf/0.1/knows> <http://example.org/ns#Alice>' ; authz:label "manager" ] .
+}

--- a/rdf-abac-fuseki/src/test/files/server/shacl-shape.ttl
+++ b/rdf-abac-fuseki/src/test/files/server/shacl-shape.ttl
@@ -1,0 +1,12 @@
+PREFIX :     <http://example.org/ns#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX sh:   <http://www.w3.org/ns/shacl#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+:PersonShape
+    a              sh:NodeShape ;
+    sh:targetClass foaf:Person ;
+    sh:property    [ sh:path     foaf:givenName ;
+                     sh:datatype xsd:string ; ] ;
+    sh:property    [ sh:path  foaf:knows ;
+                     sh:class foaf:Person ; ] .

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TS_ABAC_Fuseki.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TS_ABAC_Fuseki.java
@@ -25,6 +25,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({
     TestServerABAC.class
     , TestServer_FMod_ABAC.class
+    , TestShaclABAC.class
     , TestAttributesStoreRemote.class
     , TestLabelledDataLoader.class
     , UserInfoEnrichmentFilterTest.class

--- a/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestShaclABAC.java
+++ b/rdf-abac-fuseki/src/test/java/io/telicent/jena/abac/fuseki/TestShaclABAC.java
@@ -1,0 +1,203 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.jena.abac.fuseki;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiModule;
+import org.apache.jena.fuseki.main.sys.FusekiModules;
+import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for ABAC-filtered SHACL validation endpoint.
+ */
+public class TestShaclABAC {
+
+    static {
+        FusekiLogging.setLogging();
+    }
+
+    private static final String DIR = "src/test/files/server/";
+
+    private static final String SHACL_TEST_DATA = """
+            Content-type: application/trig
+            
+            PREFIX authz: <http://telicent.io/security#>
+            PREFIX ex:    <http://example.org/ns#>
+            PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+            
+            ex:Alice
+                a              foaf:Person ;
+                foaf:givenName "Alice" ;
+                foaf:knows     ex:Bob .
+            
+            ex:Bob
+                a              foaf:Person ;
+                foaf:givenName "Bob" ;
+                foaf:knows     ex:Alice .
+            
+            GRAPH authz:labels {
+                [ authz:pattern '<http://example.org/ns#Alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/ns#Bob>' ; authz:label "manager" ] .
+                [ authz:pattern '<http://example.org/ns#Bob> <http://xmlns.com/foaf/0.1/knows> <http://example.org/ns#Alice>' ; authz:label "manager" ] .
+            }
+            """;
+
+    private static final String PERSON_SHAPE_BAD = """
+            PREFIX :     <http://example.org/ns#>
+            PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+            PREFIX schema: <http://schema.org/>
+            PREFIX sh:   <http://www.w3.org/ns/shacl#>
+            PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+            
+            :PersonShape
+                a              sh:NodeShape ;
+                sh:targetClass foaf:Person ;
+                sh:property    [ sh:path     foaf:givenName ;
+                                 sh:datatype xsd:string ; ] ;
+                sh:property    [ sh:path  foaf:knows ;
+                                 sh:class schema:Person ; ] .
+            """;
+
+    private static final String PERSON_SHAPE_GOOD = """
+            PREFIX :     <http://example.org/ns#>
+            PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+            PREFIX sh:   <http://www.w3.org/ns/shacl#>
+            PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+            
+            :PersonShape
+                a              sh:NodeShape ;
+                sh:targetClass foaf:Person ;
+                sh:property    [ sh:path     foaf:givenName ;
+                                 sh:datatype xsd:string ; ] ;
+                sh:property    [ sh:path  foaf:knows ;
+                                 sh:class foaf:Person ; ] .
+            """;
+
+    private static final String SH_CONFORMS = "http://www.w3.org/ns/shacl#conforms";
+
+    private FusekiServer server;
+    private String shaclURL;
+
+    @BeforeAll
+    public static void beforeAll() {
+        FusekiLogging.setLogging();
+    }
+
+    @BeforeEach
+    public void setup() {
+        final FusekiModule fmod = new FMod_ABAC();
+        final FusekiModules mods = FusekiModules.create(List.of(fmod));
+        server = FusekiServer.create()
+                .port(0)
+                .fusekiModules(mods)
+                .parseConfigFile(FileOps.concatPaths(DIR, "config-server-shacl.ttl"))
+                .build()
+                .start();
+
+        final String base = "http://localhost:" + server.getPort() + "/ds";
+        shaclURL = base + "/shacl?default";
+        final String uploadURL = base + "/upload";
+        PlayLib.sendStringHTTP(uploadURL, SHACL_TEST_DATA);
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (server != null)
+            server.stop();
+    }
+
+    @Test
+    public void givenNoAuthorizationHeader_whenShaclValidate_thenBadRequest() throws IOException, InterruptedException {
+        final HttpResponse<String> response = shaclPost(shaclURL, null, PERSON_SHAPE_GOOD);
+        assertEquals(400, response.statusCode());
+    }
+
+    @Test
+    public void givenManagerUser_whenShaclValidate_thenViolationReportedForSecurityLabelledData()
+            throws IOException, InterruptedException {
+        // User u1 has the manager attribute and can see the foaf:knows relationship which according to the SHACL
+        // should have a schema:Person as the object class. In the data foaf:knows points to a foaf:Person so the shape
+        // must report a violation.
+        final HttpResponse<String> response = shaclPost(shaclURL, "u1", PERSON_SHAPE_BAD);
+        assertEquals(200, response.statusCode());
+        assertFalse(shaclConforms(response.body()), "Expected SHACL violation for u1 (manager)");
+    }
+
+    @Test
+    public void givenManagerUser_whenShaclValidate_thenNoViolationForSecurityLabelledData()
+            throws IOException, InterruptedException {
+        // User u1 has the manager attribute and can see the foaf:knows relationship which according to the SHACL
+        // should have a foaf:Person as the object class. The data conforms to this shape so no violation should be
+        // reported.
+        final HttpResponse<String> response = shaclPost(shaclURL, "u1", PERSON_SHAPE_GOOD);
+        assertEquals(200, response.statusCode());
+        assertTrue(shaclConforms(response.body()), "Expected SHACL to conform for u1 (manager)");
+    }
+
+    @Test
+    public void givenEngineerUser_whenShaclValidate_thenNoViolationForVisibleData()
+            throws IOException, InterruptedException {
+        // User u2 has the engineer attribute and cannot see the foaf:knows relationship. The visible data conforms to
+        // the SHACL shape so no violation should be seen.
+        final HttpResponse<String> response = shaclPost(shaclURL, "u2", PERSON_SHAPE_GOOD);
+        assertEquals(200, response.statusCode());
+        assertTrue(shaclConforms(response.body()), "Expected SHACL to conform for u2 (engineer)");
+    }
+
+    private static HttpResponse<String> shaclPost(String url, String user, String shaclShape)
+            throws IOException, InterruptedException {
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "text/turtle")
+                .POST(HttpRequest.BodyPublishers.ofString(shaclShape));
+        if (user != null) {
+            builder.header("Authorization", "Bearer user:" + user);
+        }
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            return client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        }
+    }
+
+    private static boolean shaclConforms(String responseTtl) {
+        final Model report = ModelFactory.createDefaultModel();
+        RDFParser.fromString(responseTtl, Lang.TTL).parse(report);
+        final Property conforms = report.createProperty(SH_CONFORMS);
+        return report.listStatements(null, conforms, (org.apache.jena.rdf.model.RDFNode) null)
+                .nextStatement()
+                .getObject()
+                .asLiteral()
+                .getBoolean();
+    }
+}


### PR DESCRIPTION
This PR enables the SHACL validation endpoint provided by Fuseki to be used with RDF ABAC filtering. This means that users can only validate data they can see.

The filtering takes place in `ABAC_SHACL_Validation` which replaces the standard Fuseki SHACL endpoint. This works in a very similar way to how querying is redirected to `ABAC_SPARQL_QueryDataset`.