### PR TITLE
Handle legacy labels store corruption (CORE-1293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log :: RDF ABAC
 
+## 3.1.1
+
+- RocksDB improvements:
+    - Improved automatic migration from legacy to modern store format.  Previously any corrupt keys/values caused the
+      entire migration to fail which could place applications into a crash-restart loop if they need to open the labels
+      store before beginning work.  Automated migration now deals more gracefully with some label store corruption, if
+      corruption is above a certain percentage then migration will still fail as heavily corrupted stores indicate more
+      serious problems whereas a few corrupted entries can be discarded.
+
 ## 3.1.0
 
 - RocksDB improvements:

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/ABAC.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/ABAC.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Set;
 
 /**
  * Programmatic API to the Attribute-Based Access Control functionality.

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/StoreFmtByHash.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/StoreFmtByHash.java
@@ -9,13 +9,14 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  *
- *  An id-based implementation of a storage format for {@code RocksDB}-based label stores.
- *  <p>
- *  Because it is using a hash to generate the ID, it is a one way process and so for processing Labels,
- *  we will use the existing String parsing {@code parseStrings()}.
+ * An id-based implementation of a storage format for {@code RocksDB}-based label stores.
+ * <p>
+ * Because it is using a hash to generate the ID, it is a one way process and so for processing Labels, we will use the
+ * existing String parsing {@code parseStrings()}.
  */
 @SuppressWarnings("deprecation")
 public class StoreFmtByHash implements StoreFmt {
@@ -23,7 +24,15 @@ public class StoreFmtByHash implements StoreFmt {
     private final Hasher hasher;
 
     public StoreFmtByHash(Hasher hasher) {
-        this.hasher = hasher;
+        this.hasher = Objects.requireNonNull(hasher, "Hasher cannot be null");
+    }
+
+    /**
+     * Gets the hasher configured for the store format
+     * @return Hasher
+     */
+    public final Hasher getHasher() {
+        return this.hasher;
     }
 
     @Override
@@ -38,6 +47,7 @@ public class StoreFmtByHash implements StoreFmt {
 
     /**
      * To aid with testing - provide a name
+     *
      * @return a toString()
      */
     @Override
@@ -109,8 +119,8 @@ public class StoreFmtByHash implements StoreFmt {
     }
 
     /**
-     * This class will only ever parse Strings - since it's reversible;
-     * as the hashing functions used in encoding are otherwise one-way only.
+     * This class will only ever parse Strings - since it's reversible; as the hashing functions used in encoding are
+     * otherwise one-way only.
      */
     public static class OnlyStringParser implements Parser {
 

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/BaseHasher.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/BaseHasher.java
@@ -35,4 +35,8 @@ public class BaseHasher extends NamedHasher {
     @Override
     public byte[] hash(byte[] input) { return hashFunction.hashBytes(input).asBytes(); }
 
+    @Override
+    public int sizeInBytes() {
+        return hashFunction.bits() / 8;
+    }
 }

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/BaseLongHasher.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/BaseLongHasher.java
@@ -24,9 +24,15 @@ public class BaseLongHasher extends NamedHasher {
         return formatLongVariable(hashValue);
     }
 
+    @Override
     public byte[] hash(byte[] input) {
         long hashValue = hashFunction.hashBytes(input);
         return formatLongVariable(hashValue);
+    }
+
+    @Override
+    public int sizeInBytes() {
+        return 8;
     }
 
     /**

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/BaseLongTupleHasher.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/BaseLongTupleHasher.java
@@ -30,6 +30,11 @@ public class BaseLongTupleHasher extends NamedHasher {
         return longArrayToByteArray(hashValue);
     }
 
+    @Override
+    public int sizeInBytes() {
+        return hashFunction.bitsLength() / 8;
+    }
+
     public static byte[] longArrayToByteArray(long[] longArray) {
         // Each long is 8 bytes, so the byte array should be longArray.length * 8 in size
         byte[] byteArray = new byte[longArray.length * Long.BYTES];

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/Hasher.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/hashing/Hasher.java
@@ -6,6 +6,7 @@ package io.telicent.jena.abac.labels.hashing;
 public interface Hasher {
     /**
      * Hashes the given input string
+     *
      * @param input Input string
      * @return Hash bytes
      */
@@ -13,8 +14,20 @@ public interface Hasher {
 
     /**
      * Hashes the given input bytes
+     *
      * @param input Input bytes
      * @return Hash bytes
      */
     byte[] hash(byte[] input);
+
+    /**
+     * Gets the size of the hash in bytes
+     * <p>
+     * This may be an upper limit if the hash function may compress the resulting hash by using fewer bytes where
+     * possible.
+     * </p>
+     *
+     * @return Size of the hash in bytes
+     */
+    int sizeInBytes();
 }

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
@@ -619,7 +619,7 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
                                     iterator.next();
                                     continue;
                                 }
-                                store.setLabel(newKey, newValue.longValue());
+                                store.setLabel(newKey, newValue);
                                 counter.incrementAndGet();
                                 batchCount++;
 

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
@@ -101,6 +101,32 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
     }
 
     /**
+     * Formats a counter in human-readable fashion i.e. with the thousand separator present
+     *
+     * @param counter Counter whose current value should be formatted
+     * @return Human-readable count as a string
+     */
+    private static String humanReadableCount(AtomicLong counter) {
+        return String.format("%,d", counter.get());
+    }
+
+    /**
+     * Calculates and formats a percentage in human-readable format
+     *
+     * @param current Current value of a counter
+     * @param total   Total count of things being processed
+     * @return A human-readable percentage formatted with 2 significant figures
+     */
+    private static String percentage(long current, long total) {
+        if (current == total) {
+            return "100%";
+        } else {
+            double percentage = (double) current / (double) total;
+            return String.format("%.2f", percentage * 100) + "%";
+        }
+    }
+
+    /**
      * Validates that the store format recorded in this database matches that with which we have been asked to open it
      * <p>
      * If this is the first time this database has been opened record the format now for future reference.
@@ -438,6 +464,8 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
         public static final byte[] LEGACY_MIGRATION_KEY = "legacyMigration".getBytes(StandardCharsets.UTF_8);
         public static final byte[] LEGACY_MIGRATION_TARGET = "legacyMigrationTarget".getBytes(StandardCharsets.UTF_8);
         public static final byte[] LEGACY_MIGRATION_COUNTER = "legacyMigrationCounter".getBytes(StandardCharsets.UTF_8);
+        public static final byte[] LEGACY_MIGRATION_CORRUPTED_COUNTER =
+                "legacyMigrationCorruptedCounter".getBytes(StandardCharsets.UTF_8);
 
         /**
          * The migration batch size, i.e. how many keys do we migrate in a single RocksDB transaction.  This is a
@@ -446,6 +474,13 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
          * throughput of roughly 3.5 million keys per minute on a representative production label store.
          */
         public static final int MIGRATION_BATCH_SIZE = 1_000_000;
+        /**
+         * Acceptable corruption threshold (currently 0.1 aka 10%) above which legacy store migrations will fail.  If
+         * there are only a few corrupt keys in the legacy store (which can happen as the legacy store isn't using
+         * RocksDB in a transaction safe manner) then we just ignore these and migrate the valid keys.
+         */
+        public static final double LEGACY_MIGRATION_ACCEPTABLE_CORRUPTION_THRESHOLD = 0.1;
+        
         private final DictionaryLabelStoreRocksDB store;
         private final byte[] defaultGraphBytes;
 
@@ -478,6 +513,7 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
             // Iterate over the legacy column family and migrate the key values
             StoreFmt.Parser parser = sourceFormat.createParser();
             AtomicLong counter = new AtomicLong(0);
+            AtomicLong corrupted = new AtomicLong(0);
             ByteBuffer migrationBuffer = ByteBuffer.allocate(LegacyLabelsStoreRocksDB.DEFAULT_BUFFER_CAPACITY * 10)
                                                    .order(ByteOrder.LITTLE_ENDIAN);
             LOGGER.info("Beginning legacy format migration...");
@@ -506,7 +542,19 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
                         counter.set(bytesToLong(lastCount));
                         LOGGER.info(
                                 "Resuming a previously interrupted partial migration, we previously migrated {} keys [{}]",
-                                String.format("%,d", counter.get()), percentage(counter.get(), keysToMigrate));
+                                humanReadableCount(counter), percentage(counter.get(), keysToMigrate));
+                    }
+
+                    // And we remember how many corrupt keys (if any) we've encountered so far
+                    byte[] lastCorruptedCount =
+                            context.get(store.getDefaultHandle(), LEGACY_MIGRATION_CORRUPTED_COUNTER);
+                    if (lastCorruptedCount != null) {
+                        corrupted.set(bytesToLong(lastCorruptedCount));
+                        if (corrupted.get() > 0) {
+                            LOGGER.warn(
+                                    "Resuming a previously interrupted partial migration, we previously encountered {} corrupted keys",
+                                    humanReadableCount(corrupted));
+                        }
                     }
 
                     context.commit();
@@ -545,14 +593,39 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
                                 byte[] newKey =
                                         migrateKey(kv.key(), sourceFormat, parser, migrationBuffer, store.storeFmt,
                                                    store.encoder);
-                                long newValue = migrateValue(kv.value(), parser, migrationBuffer);
-                                store.setLabel(newKey, newValue);
+                                if (newKey == null) {
+                                    // Corrupted key encountered, this will already have been logged so just increment
+                                    // our counters and move onto the next key value
+                                    // When we've seen this with live databases this has only occurred at the very end
+                                    // of a column family suggesting a corrupted trailing write so probably safe to
+                                    // ignore the corrupted key and move on
+                                    counter.incrementAndGet();
+                                    corrupted.incrementAndGet();
+                                    batchCount++;
+                                    // NB - Must move to next key before continue otherwise we'll loop infinitely at
+                                    //      this corrupt key
+                                    iterator.next();
+                                    continue;
+                                }
+                                Long newValue = migrateValue(kv.value(), parser, migrationBuffer);
+                                if (newValue == null) {
+                                    // Corrupted value encountered, this will already have been logged so just increment
+                                    // our counters and move onto the next key value
+                                    counter.incrementAndGet();
+                                    corrupted.incrementAndGet();
+                                    batchCount++;
+                                    // NB - Must move to next key before continue otherwise we'll loop infinitely at
+                                    //      this corrupt value
+                                    iterator.next();
+                                    continue;
+                                }
+                                store.setLabel(newKey, newValue.longValue());
                                 counter.incrementAndGet();
                                 batchCount++;
 
                                 if (counter.get() % 100_000 == 0) {
                                     LOGGER.info("Legacy format migration in progress, migrated {} keys [{}] so far...",
-                                                String.format("%,d", counter.get()),
+                                                humanReadableCount(counter),
                                                 percentage(counter.get(), keysToMigrate));
                                 }
 
@@ -571,6 +644,8 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
                             // interrupted and later need to resume we can report this while providing an accurate
                             // count
                             context.put(store.getDefaultHandle(), LEGACY_MIGRATION_COUNTER, longToBytes(counter.get()));
+                            context.put(store.getDefaultHandle(), LEGACY_MIGRATION_CORRUPTED_COUNTER,
+                                        longToBytes(corrupted.get()));
                         }
 
                         // Commit the current batch of migrated data
@@ -578,7 +653,19 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
                     }
                 }
                 LOGGER.info("Completed legacy format migration, {} labels were migrated [{}]",
-                            String.format("%,d", counter.get()), percentage(counter.get(), keysToMigrate));
+                            humanReadableCount(counter), percentage(counter.get(), keysToMigrate));
+                if (corrupted.get() > 0) {
+                    LOGGER.warn(
+                            "Completed legacy format migration, {} corrupted keys did not have their labels migrated [{}]",
+                            humanReadableCount(corrupted), percentage(corrupted.get(), keysToMigrate));
+                }
+                if (exceedsThreshold(corrupted.get(), counter.get(),
+                                     LEGACY_MIGRATION_ACCEPTABLE_CORRUPTION_THRESHOLD)) {
+                    // If too many entries were corrupted then fail horribly
+                    throw new IllegalStateException(
+                            "RocksDB store at " + dbPath.getAbsolutePath() + " contains data in a legacy format which we failed to migrate successfully - too many keys were corrupt (" + percentage(
+                                    corrupted.get(), keysToMigrate) + ")");
+                }
 
                 // Upon successful migration set the legacyMigration key to true
                 // And update the store format key to match our current format (which may differ from the legacy format)
@@ -600,18 +687,31 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
             } catch (Throwable e) {
                 LOGGER.error("Legacy format migration failed/interrupted: ", e);
                 store.close();
-                throw new IllegalStateException(
-                        "RocksDB store at " + dbPath.getAbsolutePath() + " contains data in a legacy format which we failed to migrate successfully");
+                if (e instanceof IllegalStateException illegalState) {
+                    throw illegalState;
+                } else {
+                    throw new IllegalStateException(
+                            "RocksDB store at " + dbPath.getAbsolutePath() + " contains data in a legacy format which we failed to migrate successfully");
+                }
             }
         }
 
-        private String percentage(long migratedSoFar, long totalToMigrate) {
-            if (migratedSoFar == totalToMigrate) {
-                return "100%";
-            } else {
-                double percentage = (double) migratedSoFar / (double) totalToMigrate;
-                return String.format("%.2f", percentage * 100) + "%";
+        /**
+         * Gets whether a calculated percentage exceeds a given threshold
+         *
+         * @param count     Count
+         * @param total     Total from which the percentage will be calculated
+         * @param threshold Threshold above which this method should return true
+         * @return True if count greater than or equal to total, or the calculated percentage exceeds the given
+         * threshold
+         */
+        private boolean exceedsThreshold(long count, long total, double threshold) {
+            if (count >= total) {
+                return true;
             }
+
+            double percentage = ((double) count) / ((double) total);
+            return percentage >= threshold;
         }
 
         /**
@@ -674,18 +774,35 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
          * @param migrationBuffer Migration buffer
          * @param targetFormat    Target format
          * @param encoder         Target format encoder
-         * @return Migrated key bytes
+         * @return Migrated key bytes or {@code null} if a corrupted key is encountered
          */
         @SuppressWarnings("deprecation")
         private byte[] migrateKey(byte[] key, StoreFmt sourceFormat, StoreFmt.Parser parser, ByteBuffer migrationBuffer,
                                   StoreFmt targetFormat,
                                   StoreFmt.Encoder encoder) {
-            if (sourceFormat == targetFormat && sourceFormat instanceof StoreFmtByHash) {
+            if (sourceFormat == targetFormat && sourceFormat instanceof StoreFmtByHash hashFormat) {
+                // NB - Verify that the existing key has the expected length, the key could be legitimately shorter than
+                //      this depending on the hash function used and whether the Hasher tries to compress the hash by
+                //      omitting empty bytes
+                int expectedKeyLength = 3 * hashFormat.getHasher().sizeInBytes();
+                if (key.length > expectedKeyLength) {
+                    LOGGER.warn(
+                            "Wrong length key encountered for StoreFmtByHash, expected keys to be of length {} bytes but got key of length {} bytes",
+                            expectedKeyLength, key.length);
+                    return null;
+                }
+
                 // Legacy store only hashed subject, predicate and object whereas modern store also hashes the graph
                 // Luckily each element is independently hashed and appended together to generate the key we can migrate
                 // the key by simply hashing the default graph node and appending it to the front of the existing key to
                 // form the key as it is expected to exist in the modern store
                 ByteBuffer buffer = store.keyBuffer.get().clear();
+                if (defaultGraphBytes.length + key.length > buffer.limit()) {
+                    LOGGER.warn(
+                            "Too long key encountered for StoreFmtByHash, expected keys to be no longer than {} bytes but got {} bytes",
+                            buffer.limit(), defaultGraphBytes.length + key.length);
+                    return null;
+                }
                 buffer.put(defaultGraphBytes);
                 buffer.put(key);
                 return asByteArray(buffer.flip());
@@ -696,9 +813,14 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
             List<Node> spo = new ArrayList<>();
             ByteBuffer buffer = migrationBuffer.clear();
             buffer.put(key);
-            parser.parseTriple(buffer.flip(), spo);
-            buffer.clear();
-            encoder.formatQuad(buffer, Quad.defaultGraphIRI, spo.get(0), spo.get(1), spo.get(2));
+            try {
+                parser.parseTriple(buffer.flip(), spo);
+                buffer.clear();
+                encoder.formatQuad(buffer, Quad.defaultGraphIRI, spo.get(0), spo.get(1), spo.get(2));
+            } catch (Throwable e) {
+                LOGGER.warn("Corrupted/too large key encountered ({} bytes), ignored and not migrated", key.length);
+                return null;
+            }
             return asByteArray(buffer.flip());
         }
 
@@ -711,11 +833,16 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
          * @return Label ID for the migrated label
          */
         @SuppressWarnings("deprecation")
-        private long migrateValue(byte[] value, StoreFmt.Parser parser, ByteBuffer buffer) {
+        private Long migrateValue(byte[] value, StoreFmt.Parser parser, ByteBuffer buffer) {
             Collection<Label> labels = new HashSet<>();
             buffer.clear();
             buffer.put(value);
-            parser.parseLabels(buffer.flip(), labels);
+            try {
+                parser.parseLabels(buffer.flip(), labels);
+            } catch (Throwable e) {
+                LOGGER.warn("Corrupted labels encountered, ignored for migration: {}", e.getMessage());
+                return null;
+            }
             if (labels.size() != 1) {
                 throw new IllegalStateException(
                         "Cannot migrate from legacy storage that has multiple distinct labels (" + labels.size() + ") associated with triples");

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/LegacyCorrupter.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/LegacyCorrupter.java
@@ -1,9 +1,7 @@
 package io.telicent.jena.abac.rocks.modern;
 
 import io.telicent.jena.abac.labels.StoreFmt;
-import io.telicent.jena.abac.labels.StoreFmtByString;
 import io.telicent.jena.abac.labels.store.rocksdb.legacy.RocksDBHelper;
-import io.telicent.smart.cache.storage.labels.rocksdb.RocksDbLabelsStore;
 import io.telicent.smart.cache.storage.rocksdb.AbstractRocksDBStorage;
 import io.telicent.smart.cache.storage.rocksdb.TransactionContext;
 import org.apache.commons.lang3.RandomUtils;
@@ -18,17 +16,46 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * This class allows opening a legacy format store and introducing some number of randomised corrupt key value pairs
+ * into the label store.  This is used by {@link TestLabelStoreMigration} to test error handling paths in the automated
+ * migration logic implemented by the code in
+ * {@link io.telicent.jena.abac.labels.store.rocksdb.modern.DictionaryLabelStoreRocksDB}.
+ * <p>
+ * Constructor parameters allow controlling how many corrupt key value pairs are introduced into the label store and the
+ * sizes of those key value pairs.
+ * </p>
+ */
 public class LegacyCorrupter extends AbstractRocksDBStorage {
-    public LegacyCorrupter(File dbDir) throws RocksDBException, IOException {
-        this(dbDir, 10, 50, 1000, 25, null);
-    }
 
-
+    /**
+     * Opens the legacy labels store in the given directory and inserts the desired number of corrupt key value pairs
+     *
+     * @param dbDir            Database directory
+     * @param totalCorruptKeys Number of corrupt key value pairs to insert
+     * @throws RocksDBException Thrown if the database cannot be opened
+     * @throws IOException      Thrown if the database cannot be opened
+     */
     public LegacyCorrupter(File dbDir, int totalCorruptKeys) throws RocksDBException, IOException {
         this(dbDir, totalCorruptKeys, 50, 1000, 25, null);
     }
 
-    public LegacyCorrupter(File dbDir, int numCorruptKeys, int minKeyLength, int maxKeyLength, int valueLength, StoreFmt storeFmt) throws
+    /**
+     * Opens the legacy labels store in the given directory and inserts the desired number of corrupt key value pairs
+     * with generated keys and values matching the parameters given
+     *
+     * @param dbDir          Database directory
+     * @param numCorruptKeys Number of corrupt key value pairs to insert
+     * @param minKeyLength   Minimum (inclusive) corrupt key length to generate
+     * @param maxKeyLength   Maximum (exclusive) corrupt key length to generate
+     * @param valueLength    Fixed corrupt value length to generate
+     * @param storeFmt       An optional store format to record in the database, allows testing the different migration
+     *                       code paths for different legacy store formats
+     * @throws IOException      Thrown if the database cannot be opened
+     * @throws RocksDBException Thrown if the database cannot be opened
+     */
+    public LegacyCorrupter(File dbDir, int numCorruptKeys, int minKeyLength, int maxKeyLength, int valueLength,
+                           StoreFmt storeFmt) throws
             IOException,
             RocksDBException {
         super(dbDir);
@@ -41,6 +68,7 @@ public class LegacyCorrupter extends AbstractRocksDBStorage {
                         StandardCharsets.UTF_8));
             }
 
+            // Inject the desired number of corrupted key value pairs
             for (int i = 1; i <= numCorruptKeys; i++) {
                 context.put(this.getHandle(RocksDBHelper.COLUMN_FAMILY_SPO),
                             RandomUtils.insecure()
@@ -53,6 +81,7 @@ public class LegacyCorrupter extends AbstractRocksDBStorage {
 
     @Override
     protected List<ColumnFamilyDescriptor> prepareColumnFamilyDescriptors(ColumnFamilyOptions cfOptions) {
+        // Returns all the column families the legacy store used
         List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
         descriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
         for (byte[] name : RocksDBHelper.LEGACY_COLUMN_FAMILIES) {

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/LegacyCorrupter.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/LegacyCorrupter.java
@@ -1,0 +1,63 @@
+package io.telicent.jena.abac.rocks.modern;
+
+import io.telicent.jena.abac.labels.StoreFmt;
+import io.telicent.jena.abac.labels.StoreFmtByString;
+import io.telicent.jena.abac.labels.store.rocksdb.legacy.RocksDBHelper;
+import io.telicent.smart.cache.storage.labels.rocksdb.RocksDbLabelsStore;
+import io.telicent.smart.cache.storage.rocksdb.AbstractRocksDBStorage;
+import io.telicent.smart.cache.storage.rocksdb.TransactionContext;
+import org.apache.commons.lang3.RandomUtils;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LegacyCorrupter extends AbstractRocksDBStorage {
+    public LegacyCorrupter(File dbDir) throws RocksDBException, IOException {
+        this(dbDir, 10, 50, 1000, 25, null);
+    }
+
+
+    public LegacyCorrupter(File dbDir, int totalCorruptKeys) throws RocksDBException, IOException {
+        this(dbDir, totalCorruptKeys, 50, 1000, 25, null);
+    }
+
+    public LegacyCorrupter(File dbDir, int numCorruptKeys, int minKeyLength, int maxKeyLength, int valueLength, StoreFmt storeFmt) throws
+            IOException,
+            RocksDBException {
+        super(dbDir);
+
+        // Add some random corruption to the legacy column family
+        try (TransactionContext context = this.begin()) {
+            // Record a StoreFmt (if set)
+            if (storeFmt != null) {
+                context.put(this.getDefaultHandle(), RocksDBHelper.STORE_FORMAT_KEY, storeFmt.toString().getBytes(
+                        StandardCharsets.UTF_8));
+            }
+
+            for (int i = 1; i <= numCorruptKeys; i++) {
+                context.put(this.getHandle(RocksDBHelper.COLUMN_FAMILY_SPO),
+                            RandomUtils.insecure()
+                                       .randomBytes(RandomUtils.insecure().randomInt(minKeyLength, maxKeyLength)),
+                            RandomUtils.insecure().randomBytes(valueLength));
+            }
+            context.commit();
+        }
+    }
+
+    @Override
+    protected List<ColumnFamilyDescriptor> prepareColumnFamilyDescriptors(ColumnFamilyOptions cfOptions) {
+        List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+        for (byte[] name : RocksDBHelper.LEGACY_COLUMN_FAMILIES) {
+            descriptors.add(new ColumnFamilyDescriptor(name, cfOptions));
+        }
+        return descriptors;
+    }
+}

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/TestLabelStoreMigration.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/TestLabelStoreMigration.java
@@ -15,7 +15,6 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.ontapi.model.OntSWRL;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.sparql.sse.SSE;
 import org.junit.jupiter.api.Assertions;

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/TestLabelStoreMigration.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/TestLabelStoreMigration.java
@@ -1,9 +1,6 @@
 package io.telicent.jena.abac.rocks.modern;
 
-import io.telicent.jena.abac.labels.Label;
-import io.telicent.jena.abac.labels.StoreFmt;
-import io.telicent.jena.abac.labels.StoreFmtByHash;
-import io.telicent.jena.abac.labels.StoreFmtByString;
+import io.telicent.jena.abac.labels.*;
 import io.telicent.jena.abac.labels.hashing.HasherUtil;
 import io.telicent.jena.abac.labels.store.rocksdb.legacy.LegacyLabelsStoreRocksDB;
 import io.telicent.jena.abac.labels.store.rocksdb.legacy.RocksDBHelper;
@@ -16,7 +13,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.ontapi.model.OntSWRL;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.sparql.sse.SSE;
 import org.junit.jupiter.api.Assertions;
@@ -37,6 +36,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 @SuppressWarnings("deprecation")
@@ -99,15 +99,8 @@ public class TestLabelStoreMigration {
         List<Label> labels = new ArrayList<>();
         try (LegacyLabelsStoreRocksDB legacyStore = new LegacyLabelsStoreRocksDB(new RocksDBHelper(), dbDir, source,
                                                                                  null)) {
-            legacyStore.getTransactional().begin(TxnType.WRITE);
-            for (int i = 1; i <= size; i++) {
-                Triple t = SSE.parseTriple(("(:s :p" + RandomUtils.insecure().randomInt(1, 10) + " '" + i + "')"));
-                triples.add(t);
-                Label l = Label.fromText(RandomStringUtils.insecure().nextAlphabetic(50));
-                labels.add(l);
-                legacyStore.add(t, l);
-            }
-            legacyStore.getTransactional().commit();
+            populateLegacyStore(size, legacyStore,
+                                () -> Label.fromText(RandomStringUtils.insecure().nextAlphabetic(50)), triples, labels);
         }
         long sizeBefore = FileUtils.sizeOfDirectory(dbDir);
 
@@ -141,15 +134,9 @@ public class TestLabelStoreMigration {
         List<Label> labels = new ArrayList<>();
         try (LegacyLabelsStoreRocksDB legacyStore = new LegacyLabelsStoreRocksDB(new RocksDBHelper(), dbDir, source,
                                                                                  null)) {
-            legacyStore.getTransactional().begin(TxnType.WRITE);
-            for (int i = 1; i <= size; i++) {
-                Triple t = SSE.parseTriple(("(:s :p" + RandomUtils.insecure().randomInt(1, 10) + " '" + i + "')"));
-                triples.add(t);
-                Label l = labelPool.get(RandomUtils.insecure().randomInt(0, labelPool.size()));
-                labels.add(l);
-                legacyStore.add(t, l);
-            }
-            legacyStore.getTransactional().commit();
+            populateLegacyStore(size, legacyStore,
+                                () -> labelPool.get(RandomUtils.insecure().randomInt(0, labelPool.size())), triples,
+                                                    labels);
         }
         long sizeBefore = FileUtils.sizeOfDirectory(dbDir);
 
@@ -179,13 +166,7 @@ public class TestLabelStoreMigration {
         Label label = Label.fromText(RandomStringUtils.insecure().nextAlphabetic(256));
         try (LegacyLabelsStoreRocksDB legacyStore = new LegacyLabelsStoreRocksDB(new RocksDBHelper(), dbDir, source,
                                                                                  null)) {
-            legacyStore.getTransactional().begin(TxnType.WRITE);
-            for (int i = 1; i <= size; i++) {
-                Triple t = SSE.parseTriple(("(:s :p" + RandomUtils.insecure().randomInt(1, 10) + " '" + i + "')"));
-                triples.add(t);
-                legacyStore.add(t, label);
-            }
-            legacyStore.getTransactional().commit();
+            populateLegacyStore(size, legacyStore, () -> label, triples, new ArrayList<>());
         }
         long sizeBefore = FileUtils.sizeOfDirectory(dbDir);
 
@@ -197,6 +178,113 @@ public class TestLabelStoreMigration {
             for (int i = 0; i < triples.size(); i++) {
                 Triple t = triples.get(i);
                 Assertions.assertEquals(label, modernStore.labelForTriple(t), "Wrong label for triple " + i);
+            }
+        }
+        long sizeAfter = FileUtils.sizeOfDirectory(dbDir);
+        reportSizes(sizeBefore, sizeAfter);
+    }
+
+    @Test
+    public void givenCorruptedLegacyStoreInHashFormat_whenOpeningWithModernStore_thenDataMigrationFails() throws
+            IOException, RocksDBException {
+        // Given
+        File dbDir = Files.createTempDirectory("rocks").toFile();
+        try (LegacyCorrupter corrupter = new LegacyCorrupter(dbDir, 1_000, 8, 128, 25,
+                                                             new StoreFmtByHash(HasherUtil.createXX128Hasher()))) {
+            corrupter.close();
+        }
+
+        // When
+        verifyMigrationFailsDueToCorruption(dbDir);
+    }
+
+    @Test
+    public void givenCorruptedLegacyStoreInStringFormat_whenOpeningWithModernStore_thenDataMigrationFails() throws
+            IOException, RocksDBException {
+        // Given
+        File dbDir = Files.createTempDirectory("rocks").toFile();
+        try (LegacyCorrupter corrupter = new LegacyCorrupter(dbDir, 100, 64, 1024, 25, new StoreFmtByString())) {
+            corrupter.close();
+        }
+
+        verifyMigrationFailsDueToCorruption(dbDir);
+    }
+
+    private static void verifyMigrationFailsDueToCorruption(File dbDir) {
+        // When
+        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () -> {
+            try (DictionaryLabelStoreRocksDB modernStore = new DictionaryLabelStoreRocksDB(dbDir, new StoreFmtByHash(
+                    HasherUtil.createXX128Hasher()))) {
+                Assertions.fail("Legacy Migration should fail when store sufficiently corrupted");
+            }
+        });
+
+        // Then
+        Assertions.assertTrue(Strings.CI.contains(e.getMessage(), "too many keys were corrupt"));
+    }
+
+    public static Stream<Arguments> partiallyCorruptSizes() {
+        return Stream.of(Arguments.of(10_000, 100, true),
+                         Arguments.of(10_000, 500, true),
+                         Arguments.of(10_000, 1_125, false),
+                         Arguments.of(1_000, 1_000, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("partiallyCorruptSizes")
+    public void givenPopulatedLegacyStoreWithSomeCorruptKeys_whenOpeningWithModernStore_thenDataAutomaticallyMigratedIfCorruptionThresholdNotExceeded(
+            int totalKeys, int totalCorruptKeys, boolean expectSuccessfulMigration) throws
+            IOException, RocksDBException {
+        // Given
+        File dbDir = Files.createTempDirectory("rocks").toFile();
+        List<Triple> triples = new ArrayList<>();
+        List<Label> labels = new ArrayList<>();
+        try (LegacyLabelsStoreRocksDB legacyStore = new LegacyLabelsStoreRocksDB(new RocksDBHelper(), dbDir,
+                                                                                 new StoreFmtByString(), null)) {
+            populateLegacyStore(totalKeys, legacyStore,
+                                () -> Label.fromText(RandomStringUtils.insecure().nextAlphabetic(50)), triples, labels);
+        }
+        // NB - This adds some corrupt keys into the database
+        try (LegacyCorrupter corrupter = new LegacyCorrupter(dbDir, totalCorruptKeys)) {
+            corrupter.close();
+        }
+
+        long sizeBefore = FileUtils.sizeOfDirectory(dbDir);
+
+        // When
+        if (expectSuccessfulMigration) {
+            migrateAndValidate(dbDir, triples, labels, sizeBefore);
+        } else {
+            verifyMigrationFailsDueToCorruption(dbDir);
+        }
+    }
+
+    private static void populateLegacyStore(int totalKeys, LegacyLabelsStoreRocksDB legacyStore,
+                                            Supplier<Label> labelGenerator, List<Triple> triples,
+                                            List<Label> labels) {
+        legacyStore.getTransactional().begin(TxnType.WRITE);
+        for (int i = 1; i <= totalKeys; i++) {
+            Triple t = SSE.parseTriple(("(:s :p" + RandomUtils.insecure().randomInt(1, 10) + " '" + i + "')"));
+            triples.add(t);
+            Label l = labelGenerator.get();
+            labels.add(l);
+            legacyStore.add(t, l);
+        }
+        legacyStore.getTransactional().commit();
+    }
+
+    private static void migrateAndValidate(File dbDir, List<Triple> triples, List<Label> labels, long sizeBefore) throws
+            RocksDBException, IOException {
+        try (DictionaryLabelStoreRocksDB modernStore = new DictionaryLabelStoreRocksDB(dbDir, new StoreFmtByHash(
+                HasherUtil.createXX128Hasher()))) {
+            Assertions.assertNotNull(modernStore);
+
+            // Then
+            for (int i = 0; i < triples.size(); i++) {
+                Triple t = triples.get(i);
+                Label expected = labels.get(i);
+
+                Assertions.assertEquals(expected, modernStore.labelForTriple(t), "Wrong label for triple " + i);
             }
         }
         long sizeAfter = FileUtils.sizeOfDirectory(dbDir);
@@ -217,8 +305,7 @@ public class TestLabelStoreMigration {
         Path dbDir = Files.createTempDirectory("rocks");
         unpackZippedData(REAL_TEST_DATA, backupDir, "ontology");
         try (LegacyLabelsStoreRocksDB legacyStore = new LegacyLabelsStoreRocksDB(new RocksDBHelper(), dbDir.toFile(),
-                                                                                 new StoreFmtByString(),
-                                                                                 null)) {
+                                                                                 new StoreFmtByString(), null)) {
             legacyStore.restore(backupDir.toFile().getAbsolutePath());
             Assertions.assertFalse(legacyStore.isEmpty());
         }
@@ -248,8 +335,7 @@ public class TestLabelStoreMigration {
         int unpacked = 0;
         LOGGER.info("Unpacking {} dataset from ZIP archive {} with size {} bytes", dataset, testDataArchive,
                     String.format("%,d", new File(testDataArchive).length()));
-        try (ArchiveInputStream<ZipArchiveEntry> i = new ZipArchiveInputStream(
-                new FileInputStream(testDataArchive))) {
+        try (ArchiveInputStream<ZipArchiveEntry> i = new ZipArchiveInputStream(new FileInputStream(testDataArchive))) {
             ZipArchiveEntry entry = null;
             while ((entry = i.getNextEntry()) != null) {
                 if (!i.canReadEntryData(entry)) {


### PR DESCRIPTION
Improves how legacy labels stores that contain some corrupt key values are handled.  Provided the percentage of corrupt keys does not exceed a threshold (currently 10% - should this be set to something lower?) then the corrupt key values are ignored and migration still completes successfully.

Any store that is more corrupt than that will fail migration as before.

Improved unit tests around store migration to intentionally introduce corruption into stores to validate the corruption handling works as intended