### PR TITLE
CORE-1310: implent LabelStore remove() for RocksDB

### DIFF
--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/legacy/LegacyLabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/legacy/LegacyLabelsStoreRocksDB.java
@@ -224,7 +224,7 @@ public class LegacyLabelsStoreRocksDB implements LabelsStore {
     public Label labelForQuad(Quad quad) {
         Quad normalized = RocksDBHelper.normalize(quad);
         Label label = labelCache.get(quad, t -> labelForQuad(normalized.getGraph(), normalized.getSubject(),
-                                                      normalized.getPredicate(), normalized.getObject()));
+                normalized.getPredicate(), normalized.getObject()));
         // NB - Label.EMPTY is used as a placeholder value so we hold database misses in the cache, otherwise every
         //      missed lookup would bypass the cache (as the cache does not store null) and require a full database
         //      lookup which is bad for performance
@@ -257,7 +257,7 @@ public class LegacyLabelsStoreRocksDB implements LabelsStore {
         if (!graph.isConcrete() || !subject.isConcrete() || !predicate.isConcrete() || !object.isConcrete()) {
             throw new LabelsException(
                     "Asked for labels for a quad with wildcards: " + NodeFmtLib.strNodesTTL(graph, subject, predicate,
-                                                                                            object));
+                            object));
         } else if (!Objects.equals(graph, Quad.defaultGraphIRI)) {
             throw new LabelsException(
                     "Asked for label for a quad outside the default graph (" + NodeFmtLib.strTTL(
@@ -433,12 +433,31 @@ public class LegacyLabelsStoreRocksDB implements LabelsStore {
     }
 
     /**
-     * Remove any labels for a specific triple. This does not affect any patterns.
+     * Remove the labels for a specific quad. This does not affect any patterns.
      */
     @Override
     public void remove(Quad quad) {
-        labelCache.remove(quad);
-        throw new UnsupportedOperationException("LabelsStore.remove not supported by LabelsStoreRockDB");
+        final Quad normalizedQuad = RocksDBHelper.normalize(quad);
+        final Node graph = normalizedQuad.getGraph();
+        final Node subject = normalizedQuad.getSubject();
+        final Node predicate = normalizedQuad.getPredicate();
+        final Node object = normalizedQuad.getObject();
+
+        if (!normalizedQuad.isConcrete()) {
+            throw new LabelsException(
+                    "Tried to remove labels for a quad with wildcards: " +
+                            NodeFmtLib.strNodesTTL(graph, subject, predicate, object));
+        }
+        if (!Objects.equals(Quad.defaultGraphIRI, graph)) {
+            throw new LabelsException(
+                    "Legacy RocksDB store only supports removing labels for quads in the default graph");
+        }
+
+        final var key = keyBuffer.get().clear();
+        encoder.formatTriple(key, subject, predicate, object);
+        txRocksDB.delete(cfhSPO, key.flip());
+
+        labelCache.remove(normalizedQuad);
     }
 
     // Information gathering count of how many labels have been added during the current session
@@ -491,8 +510,8 @@ public class LegacyLabelsStoreRocksDB implements LabelsStore {
      */
     private long getApproximateSize(ColumnFamilyHandle cfh, byte[] first, byte[] last) {
         final long[] sizes = rocksDB.getApproximateSizes(cfh, List.of(new Range(new Slice(first), new Slice(last))),
-                                                         SizeApproximationFlag.INCLUDE_FILES,
-                                                         SizeApproximationFlag.INCLUDE_MEMTABLES);
+                SizeApproximationFlag.INCLUDE_FILES,
+                SizeApproximationFlag.INCLUDE_MEMTABLES);
 
         if (sizes.length != 1) {
             throw new RuntimeException("Unexpected size range of RocksDB column family: " + sizes.length);
@@ -536,7 +555,7 @@ public class LegacyLabelsStoreRocksDB implements LabelsStore {
         LOG.info("RocksDB label store: perform compaction");
         try {
             for (var cfh : allColumnFamilies()) {
-                var from = new byte[] {};
+                var from = new byte[]{};
                 var to = new byte[16];
                 for (int i = 0; i < 16; i++)
                     to[i] = (byte) -1;

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/legacy/TransactionalRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/legacy/TransactionalRocksDB.java
@@ -225,24 +225,31 @@ public class TransactionalRocksDB implements Transactional {
         rocksOperation(AbstractWriteBatch::put, columnFamilyHandle, key, value);
     }
 
+    public void delete(ColumnFamilyHandle columnFamilyHandle, ByteBuffer key) {
+        rocksOperation((batch, cfh, k, v) -> batch.delete(cfh, k), columnFamilyHandle, key, ByteBuffer.allocate(0));
+    }
+
     public interface WriteOperation {
-        public void write(WriteBatch writeBatch, ColumnFamilyHandle columnFamilyHandle, byte[] key, byte[] value)
+        void write(WriteBatch writeBatch, ColumnFamilyHandle columnFamilyHandle, byte[] key, byte[] value)
             throws RocksDBException;
     }
 
     private void rocksOperation(WriteOperation op, ColumnFamilyHandle columnFamilyHandle, ByteBuffer key, ByteBuffer value) {
         var transactionExists = getThisTxnType().isPresent();
-        if (!transactionExists)
+        if (!transactionExists) {
             begin(TxnType.WRITE);
-
-        if ( getThisTxnMode().get() == ReadWrite.READ ) {
-            Optional<TxnType> txnType = getThisTxnType();
-            switch (txnType.get()) {
-                case READ -> throw new JenaTransactionException("Cannot promote READ transaction to write");
-                case READ_PROMOTE -> promote(Promote.ISOLATED);
-                case READ_COMMITTED_PROMOTE -> throw new JenaTransactionException("Promoting READ_COMMITTED_PROMOTE transaction to write is not supported");
-                case WRITE -> {}
-            };
+        }
+        if(getThisTxnMode().isPresent()) {
+            if (getThisTxnMode().get() == ReadWrite.READ) {
+                Optional<TxnType> txnType = getThisTxnType();
+                switch (txnType.get()) {
+                    case READ -> throw new JenaTransactionException("Cannot promote READ transaction to write");
+                    case READ_PROMOTE -> promote(Promote.ISOLATED);
+                    case READ_COMMITTED_PROMOTE ->
+                            throw new JenaTransactionException("Promoting READ_COMMITTED_PROMOTE transaction to write is not supported");
+                    default -> throw new JenaTransactionException("Unexpected transaction type: " + txnType.get());
+                }
+            }
         }
 
         try {
@@ -260,4 +267,5 @@ public class TransactionalRocksDB implements Transactional {
             end();
         }
     }
+
 }

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
@@ -322,11 +322,30 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
 
     @Override
     public void remove(Quad quad) {
-        // This is an intentional choice.  The reasoning is that if we allow removing labels a malicious attacker can
-        // downgrade/remove labels by sending patches that first deletes quads, and then re-adds them without a security
-        // label
-        // However this does have a storage cost over time so we may revisit this in the future
-        throw new UnsupportedOperationException("Removing labels is not supported");
+        final Quad normalizedQuad = RocksDBHelper.normalize(quad);
+        final Node graph = normalizedQuad.getGraph();
+        final Node subject = normalizedQuad.getSubject();
+        final Node predicate = normalizedQuad.getPredicate();
+        final Node object = normalizedQuad.getObject();
+
+        if (!normalizedQuad.isConcrete()) {
+            throw new LabelsException(
+                    "Tried to remove labels for a quad with wildcards: " +
+                            NodeFmtLib.strNodesTTL(graph, subject, predicate, object));
+        }
+        final ByteBuffer buffer = keyBuffer.get().clear();
+        this.encoder.formatQuad(buffer, graph, subject, predicate, object);
+        buffer.flip();
+        final byte[] key = asByteArray(buffer);
+
+        try (TransactionContext context = this.begin()) {
+            context.delete(this.getHandle(KEYS_TO_LABELS_CF), key);
+            context.commit();
+        } catch (RocksDBException e) {
+            throw new LabelsException("Failed to remove label from RocksDB", e);
+        }
+
+        labelCache.remove(normalizedQuad);
     }
 
     @Override

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/AbstractTestLegacyLabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/AbstractTestLegacyLabelsStoreRocksDB.java
@@ -16,11 +16,6 @@
 
 package io.telicent.jena.abac.rocks;
 
-import static org.apache.jena.sparql.sse.SSE.parseTriple;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.stream.Stream;
-
 import io.telicent.jena.abac.ABACTests;
 import io.telicent.jena.abac.AbstractTestLabelsStore;
 import io.telicent.jena.abac.labels.*;
@@ -28,10 +23,16 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.core.Quad;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.apache.jena.sparql.sse.SSE.parseTriple;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test storing labels, parameterized for LabelsStoreRocksDB.
@@ -45,7 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public abstract class AbstractTestLegacyLabelsStoreRocksDB {
 
     protected static final Triple triple1 = parseTriple("(:s :p 123)");
+    protected static final Quad quad1 = Quad.create(Quad.defaultGraphIRI, triple1);
     protected static final Triple triple2 = parseTriple("(:s :p 'xyz')");
+    protected static final Quad quad2 = Quad.create(Quad.defaultGraphIRI, triple2);
 
     protected abstract LabelsStore createLabelsStore(StoreFmt storeFmt);
 
@@ -149,4 +152,34 @@ public abstract class AbstractTestLegacyLabelsStoreRocksDB {
         Label labels = store.labelForTriple(triple1);
         assertEquals(Label.fromText("TheLabel"), labels);
     }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void labelsStore_remove_basic(StoreFmt storeFmt) {
+        store = createLabelsStore(storeFmt);
+        store.add(quad1, Label.fromText("label-1"));
+        assertNotNull(store.labelForQuad(quad1));
+        store.remove(quad1);
+        assertNull(store.labelForQuad(quad1));
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void labelsStore_remove_nonexistent(StoreFmt storeFmt) {
+        store = createLabelsStore(storeFmt);
+        assertDoesNotThrow(() -> store.remove(quad1));
+        assertNull(store.labelForQuad(quad1));
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void labelsStore_remove_one_of_multiple(StoreFmt storeFmt) {
+        store = createLabelsStore(storeFmt);
+        store.add(quad1, Label.fromText("label-1"));
+        store.add(quad2, Label.fromText("label-2"));
+        store.remove(quad1);
+        assertNull(store.labelForQuad(quad1));
+        assertEquals(Label.fromText("label-2"), store.labelForQuad(quad2));
+    }
+
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/BaseTestLegacyLabelsStoreRocksDB.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/BaseTestLegacyLabelsStoreRocksDB.java
@@ -4,7 +4,9 @@ import io.telicent.jena.abac.labels.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.Quad;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.rocksdb.RocksDBException;
@@ -75,5 +77,20 @@ public abstract class BaseTestLegacyLabelsStoreRocksDB extends AbstractTestLegac
         assertThrows(RuntimeException.class, () -> {
             Label x = store.labelForTriple(Triple.create(triple1.getSubject(), triple1.getObject(), Node.ANY));  //warning
         });
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void labelsStore_remove_wildcard(StoreFmt storeFmt) {
+        store = createLabelsStore(storeFmt);
+        assertThrows(LabelsException.class, () -> store.remove(Triple.ANY));
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void labelsStore_remove_named_graph(StoreFmt storeFmt) {
+        store = createLabelsStore(storeFmt);
+        final Quad namedGraphQuad = Quad.create(NodeFactory.createURI("http://example.org/graph#1"), triple1);
+        assertThrows(LabelsException.class, () -> store.remove(namedGraphQuad));
     }
 }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/AbstractTestLabelMatchModernRocks.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/AbstractTestLabelMatchModernRocks.java
@@ -1,15 +1,29 @@
 package io.telicent.jena.abac.rocks.modern;
 
+import io.telicent.jena.abac.labels.Label;
+import io.telicent.jena.abac.labels.LabelsException;
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.jena.abac.labels.StoreFmt;
 import io.telicent.jena.abac.labels.store.rocksdb.modern.DictionaryLabelStoreRocksDB;
 import io.telicent.jena.abac.rocks.AbstractTestLabelMatchRocks;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.sse.SSE;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class AbstractTestLabelMatchModernRocks extends AbstractTestLabelMatchRocks {
+
+    private static final Node s = SSE.parseNode(":s");
+    private static final Node p = SSE.parseNode(":p");
+    private static final Node o = SSE.parseNode(":o");
 
     @Override
     protected LabelsStore createLabelsStore(StoreFmt storeFmt) {
@@ -18,6 +32,58 @@ public class AbstractTestLabelMatchModernRocks extends AbstractTestLabelMatchRoc
             return new DictionaryLabelStoreRocksDB(dbDirectory, storeFmt);
         } catch (RocksDBException | IOException e) {
             throw new RuntimeException("Unable to create RocksDB label store", e);
+        }
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void remove_existingLabel_removesIt(StoreFmt storeFmt) throws Exception {
+        try (LabelsStore store = createLabelsStore(storeFmt)) {
+            final Triple triple = Triple.create(s, p, o);
+            final Quad quad = Quad.create(Quad.defaultGraphIRI, triple);
+            final Label label = Label.fromText("sensitive");
+            store.add(quad, label);
+            assertEquals(label, store.labelForQuad(quad));
+
+            store.remove(quad);
+
+            assertNull(store.labelForQuad(quad));
+        }
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void remove_nonExistentLabel_isNoOp(StoreFmt storeFmt) throws Exception {
+        try (LabelsStore store = createLabelsStore(storeFmt)) {
+            final Triple triple = Triple.create(s, p, o);
+            final Quad quad = Quad.create(Quad.defaultGraphIRI, triple);
+            assertDoesNotThrow(() -> store.remove(quad));
+            assertNull(store.labelForQuad(quad));
+        }
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void remove_wildcardQuad_throwsLabelsException(StoreFmt storeFmt) throws Exception {
+        try (LabelsStore store = createLabelsStore(storeFmt)) {
+            final Quad wildcard = Quad.create(Quad.defaultGraphIRI, Node.ANY, p, o);
+            assertThrows(LabelsException.class, () -> store.remove(wildcard));
+        }
+    }
+
+    @ParameterizedTest(name = "{index}: Store = {0}")
+    @MethodSource("provideStorageFormat")
+    public void remove_thenReAdd_labelIsVisibleAgain(StoreFmt storeFmt) throws Exception {
+        try (LabelsStore store = createLabelsStore(storeFmt)) {
+            final Triple triple = Triple.create(s, p, o);
+            final Quad quad = Quad.create(Quad.defaultGraphIRI, triple);
+            final Label label = Label.fromText("public");
+            store.add(quad, label);
+            store.remove(quad);
+            assertNull(store.labelForQuad(quad));
+
+            store.add(quad, label);
+            assertEquals(label, store.labelForQuad(quad));
         }
     }
 }


### PR DESCRIPTION
Adding implementation of `remove(Quad quad)` to `DictionaryLabelStoreRocksDB` and `LegacyLabelsStoreRocksDB`. 