### PR TITLE
[CORE-1350] Identify Read/Write transactions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,16 +9,16 @@ on:
       - '**'
   workflow_dispatch:
 
+# Only permit one build per branch/tag
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: ${{ !contains(github.ref_name, 'release/') }}
 
 jobs:
   maven-build:
-    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@main
-    permissions:
-      contents: write
-      id-token: write
-      issues: write
-      packages: write
-      pull-requests: write
+    # Use the parallel build workflow (as Smart Cache Storage does); its build jobs pass -Dgpg.skip so signing only
+    # happens in the publish job, and that step gracefully skips signing when no GPG_PRIVATE_KEY secret is present.
+    uses: telicent-oss/shared-workflows/.github/workflows/parallel-maven.yml@main
     with:
       # No Docker based tests in this repository
       USES_DOCKERHUB_IMAGES: false
@@ -26,5 +26,4 @@ jobs:
       PUBLISH_SNAPSHOTS: true
       MAIN_BRANCH: main
       JAVA_VERSION: 21
-      RUN_WINDOWS_BUILD: false
     secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <!-- Dependency Plugins -->
     <!-- Internal dependencies -->
     <dependency.jena>6.1.0</dependency.jena>
-    <dependency.smart-cache-storage>0.11.2</dependency.smart-cache-storage>
+    <dependency.smart-cache-storage>0.11.5</dependency.smart-cache-storage>
 
     <!-- External dependencies -->
     <dependency.assert>3.27.7</dependency.assert>

--- a/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
+++ b/rdf-abac-core/src/main/java/io/telicent/jena/abac/labels/store/rocksdb/modern/DictionaryLabelStoreRocksDB.java
@@ -249,6 +249,12 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
         return label == Label.EMPTY ? null : label;
     }
 
+    private void verifyWritableTransaction() {
+        if (this.wrapper.isInTransaction() && !this.wrapper.isWriteLikeTransaction()) {
+            throw new JenaTransactionException("Cannot write in a read-only transaction");
+        }
+    }
+
     protected Label labelForQuadInternal(Quad quad) {
         quad = RocksDBHelper.normalize(quad);
         if (!quad.isConcrete()) {
@@ -290,6 +296,7 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
 
     @Override
     public void add(Quad quad, Label label) {
+        verifyWritableTransaction();
         quad = RocksDBHelper.normalize(quad);
 
         if (!quad.isConcrete()) {
@@ -331,7 +338,7 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
 
     @Override
     public boolean isEmpty() {
-        try (TransactionContext context = this.begin()) {
+        try (TransactionContext context = this.beginReadOnly()) {
             return context.isEmpty(this.getHandle(KEYS_TO_LABELS_CF));
         }
     }
@@ -379,6 +386,8 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
 
         private final DictionaryLabelStoreRocksDB store;
         private final ThreadLocal<TransactionContext> context;
+        private final ThreadLocal<TxnType> requestedTxnType;
+        private final ThreadLocal<Boolean> promotedToWrite;
 
         /**
          * Creates a new transaction wrapper
@@ -388,12 +397,36 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
         JenaTransactionWrapper(DictionaryLabelStoreRocksDB store) {
             this.store = store;
             this.context = ThreadLocal.withInitial(() -> null);
+            this.requestedTxnType = ThreadLocal.withInitial(() -> null);
+            this.promotedToWrite = ThreadLocal.withInitial(() -> Boolean.FALSE);
         }
 
         @Override
         public void begin(TxnType type) {
             verifyNoTransaction();
-            this.context.set(this.store.beginNested());
+            beginInternal(type != null ? type : TxnType.WRITE);
+        }
+
+        @Override
+        public void begin(ReadWrite readWrite) {
+            verifyNoTransaction();
+            beginInternal(readWrite == ReadWrite.READ ? TxnType.READ : TxnType.WRITE);
+        }
+
+        @Override
+        public void begin() {
+            verifyNoTransaction();
+            beginInternal(TxnType.WRITE);
+        }
+
+        private void beginInternal(TxnType type) {
+            this.context.set(requiresWriteContext(type) ? this.store.beginNested() : this.store.beginReadOnly());
+            this.requestedTxnType.set(type);
+            this.promotedToWrite.set(Boolean.FALSE);
+        }
+
+        private boolean requiresWriteContext(TxnType type) {
+            return type == TxnType.WRITE;
         }
 
         private void verifyNoTransaction() {
@@ -411,8 +444,21 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
         @Override
         public boolean promote(Promote mode) {
             verifyTransaction();
-            // We consider all transactions to be write transactions so this MUST always return true per Jena API
-            // contract
+            if (isWriteLikeTransaction()) {
+                return true;
+            }
+
+            TxnType type = this.requestedTxnType.get();
+            if (type != TxnType.READ && type != TxnType.READ_PROMOTE && type != TxnType.READ_COMMITTED_PROMOTE) {
+                return false;
+            }
+
+            TransactionContext current = this.context.get();
+            if (current != null) {
+                current.close();
+            }
+            this.context.set(this.store.beginNested());
+            this.promotedToWrite.set(Boolean.TRUE);
             return true;
         }
 
@@ -421,6 +467,7 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
             verifyTransaction();
             try {
                 this.context.get().commit();
+                cleanupTransactionContext(false);
             } catch (RocksDBException e) {
                 throw new JenaTransactionException(e);
             }
@@ -429,32 +476,63 @@ public class DictionaryLabelStoreRocksDB extends RocksDbLabelsStore implements L
         @Override
         public void abort() {
             verifyTransaction();
-            this.context.get().close();
-            // If a transaction aborts then need to clear out the cache otherwise changes will leak beyond the aborted
-            // transaction
-            store.labelCache.clear();
+            cleanupTransactionContext(true);
         }
 
         @Override
         public void end() {
             // The Jena contract (at least when using its Txn helper) is that end() always gets called even after a
             // commit()/abort()
-            if (isInTransaction()) {
+            TransactionContext current = this.context.get();
+            if (current == null) {
+                return;
+            }
+            if (current.isActive()) {
                 // If a transaction ends without a commit we need to treat this as an abort and clear the label
                 // cache otherwise changes will leak beyond the aborted transaction
-                store.labelCache.clear();
-                this.context.get().close();
+                cleanupTransactionContext(true);
+            } else {
+                clearThreadLocals();
             }
+        }
+
+        private boolean isWriteLikeTransaction() {
+            TxnType requestedType = this.requestedTxnType.get();
+            return requestedType == TxnType.WRITE || Boolean.TRUE.equals(this.promotedToWrite.get());
+        }
+
+        /**
+         * Ensure the nested transaction context is fully closed so RocksDB read/write options do not linger until a
+         * later end() call.
+         */
+        private void cleanupTransactionContext(boolean clearCache) {
+            TransactionContext current = this.context.get();
+            try {
+                if (clearCache) {
+                    store.labelCache.clear();
+                }
+                if (current != null) {
+                    current.close();
+                }
+            } finally {
+                clearThreadLocals();
+            }
+        }
+
+        private void clearThreadLocals() {
+            this.context.remove();
+            this.requestedTxnType.remove();
+            this.promotedToWrite.remove();
         }
 
         @Override
         public ReadWrite transactionMode() {
-            return isInTransaction() ? ReadWrite.WRITE : null;
+            return isInTransaction() ? (isWriteLikeTransaction() ? ReadWrite.WRITE : ReadWrite.READ) : null;
         }
 
         @Override
         public TxnType transactionType() {
-            return isInTransaction() ? TxnType.WRITE : null;
+            return isInTransaction() ? this.requestedTxnType.get() : null;
         }
 
         @Override

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractionTransactionalTests.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractionTransactionalTests.java
@@ -111,6 +111,18 @@ public abstract class AbstractionTransactionalTests {
     }
 
     @Test
+    public void givenStoreTransactional_whenWritingInPlainRead_thenFails() throws Exception {
+        try (LabelsStore store = create()) {
+            Transactional transactional = store.getTransactional();
+            transactional.begin(TxnType.READ);
+
+            Assertions.assertThrows(JenaTransactionException.class, () -> store.add(TRIPLE, LABEL));
+
+            transactional.end();
+        }
+    }
+
+    @Test
     public void givenStoreTransactional_whenPromotingFromWrite_thenOk() throws Exception {
         // Given
         try (LabelsStore store = create()) {
@@ -140,6 +152,24 @@ public abstract class AbstractionTransactionalTests {
             transactional.commit();
 
             // Then
+            Assertions.assertEquals(LABEL, store.labelForTriple(TRIPLE));
+        }
+    }
+
+    @Test
+    public void givenStoreTransactional_whenExecutingWriteInsideReadPromote_thenAutoPromotes() throws Exception {
+        try (LabelsStore store = create()) {
+            Transactional transactional = store.getTransactional();
+            transactional.begin(TxnType.READ_PROMOTE);
+            Assertions.assertEquals(ReadWrite.READ, transactional.transactionMode());
+
+            Txn.executeWrite(transactional, () -> {
+                Assertions.assertEquals(ReadWrite.WRITE, transactional.transactionMode());
+                store.add(TRIPLE, LABEL);
+            });
+
+            transactional.commit();
+
             Assertions.assertEquals(LABEL, store.labelForTriple(TRIPLE));
         }
     }

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractionTransactionalTests.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/AbstractionTransactionalTests.java
@@ -26,6 +26,20 @@ public abstract class AbstractionTransactionalTests {
      */
     protected abstract LabelsStore create();
 
+    /**
+     * Whether the store under test actively enforces read-only transactions by rejecting writes.
+     * <p>
+     * Only stores with genuine read/write transaction awareness (currently the modern RocksDB store) do this; the
+     * in-memory and legacy stores treat every transaction as a write and so never reject writes.  Such stores
+     * override this to enable the read-only write rejection test.
+     * </p>
+     *
+     * @return True if writes in a read-only transaction are rejected, false otherwise
+     */
+    protected boolean enforcesReadOnlyTransactions() {
+        return false;
+    }
+
     @Test
     public void givenStoreTransactional_whenCallingPlainBegin_thenWriteTransaction() throws Exception {
         // Given
@@ -114,6 +128,9 @@ public abstract class AbstractionTransactionalTests {
     public void givenStoreTransactional_whenWritingInPlainRead_thenFails() throws Exception {
         try (LabelsStore store = create()) {
             Transactional transactional = store.getTransactional();
+            // Only stores that actively enforce read-only transactions reject writes; the in-memory and legacy stores
+            // treat every transaction as a write, so this assertion only applies where enforcement exists.
+            Assumptions.assumeTrue(enforcesReadOnlyTransactions());
             transactional.begin(TxnType.READ);
 
             Assertions.assertThrows(JenaTransactionException.class, () -> store.add(TRIPLE, LABEL));

--- a/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/TestTransactionalModern.java
+++ b/rdf-abac-core/src/test/java/io/telicent/jena/abac/rocks/modern/TestTransactionalModern.java
@@ -19,4 +19,10 @@ public class TestTransactionalModern extends AbstractionTransactionalTests {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    protected boolean enforcesReadOnlyTransactions() {
+        // The modern store distinguishes read-only transactions and rejects writes made within them
+        return true;
+    }
 }


### PR DESCRIPTION
Updating SC Storage version to pick up performance improvements.
Introducing checks to makes sure we use the proper transactions when we know it's a read-only transaction. 

Plus some general tidy-up